### PR TITLE
Fix the ci-test.yml and dagger-compiler CVE

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -16,8 +16,9 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup Java 17
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
+          distribution: 'corretto'
           java-version: '17'
 
       - name: Run build and test

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ dependencies {
     implementation 'com.google.guava:guava:32.0.1-jre'
 
     implementation 'com.google.dagger:dagger:2.51'
-    annotationProcessor 'com.google.dagger:dagger-compiler:2.48'
+    annotationProcessor 'com.google.dagger:dagger-compiler:2.51'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.3'
     implementation 'org.opensearch.client:opensearch-rest-high-level-client:2.11.0'
     implementation 'org.apache.httpcomponents.client5:httpclient5:5.2.1'


### PR DESCRIPTION
### Description
Fix the ci-test.yml and dagger-compiler CVE

### Issues Resolved
https://github.com/opensearch-project/opensearch-metrics/pull/16

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
