### PR TITLE
Added canary url and stepfunction monitoring with sns email and slack…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ infrastructure/**/*.js
 infrastructure/!jest.config.js
 infrastructure/**/*.d.ts
 infrastructure/node_modules
+!infrastructure/canary/nodejs/node_modules/index.js
 
 # CDK asset staging directory
 infrastructure/.cdk.staging

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     implementation 'io.github.acm19:aws-request-signing-apache-interceptor:2.3.1'
 
     implementation 'com.amazonaws:aws-lambda-java-core:1.2.3'
+    implementation 'com.amazonaws:aws-lambda-java-events:3.7.0'
 
     implementation 'com.google.code.gson:gson:2.10.1'
 

--- a/infrastructure/canary/nodejs/node_modules/index.js
+++ b/infrastructure/canary/nodejs/node_modules/index.js
@@ -1,0 +1,102 @@
+const { URL } = require('url');
+const synthetics = require('Synthetics');
+const log = require('SyntheticsLogger');
+const syntheticsConfiguration = synthetics.getConfiguration();
+const syntheticsLogHelper = require('SyntheticsLogHelper');
+
+const loadBlueprint = async function () {
+
+    const urls = [process.env.SITE_URL];
+
+    // Set screenshot option
+    const takeScreenshot = true;
+
+    /* Disabling default step screen shots taken during Synthetics.executeStep() calls
+     * Step will be used to publish metrics on time taken to load dom content but
+     * Screenshots will be taken outside the executeStep to allow for page to completely load with domcontentloaded
+     * You can change it to load, networkidle0, networkidle2 depending on what works best for you.
+     */
+    syntheticsConfiguration.disableStepScreenshots();
+    syntheticsConfiguration.setConfig({
+        continueOnStepFailure: true,
+        includeRequestHeaders: true, // Enable if headers should be displayed in HAR
+        includeResponseHeaders: true, // Enable if headers should be displayed in HAR
+        restrictedHeaders: [], // Value of these headers will be redacted from logs and reports
+        restrictedUrlParameters: [] // Values of these url parameters will be redacted from logs and reports
+
+    });
+
+    let page = await synthetics.getPage();
+
+    for (const url of urls) {
+        await loadUrl(page, url, takeScreenshot);
+    }
+};
+
+// Reset the page in-between
+const resetPage = async function(page) {
+    try {
+        await page.goto('about:blank',{waitUntil: ['load', 'networkidle0'], timeout: 30000} );
+    } catch (e) {
+        synthetics.addExecutionError('Unable to open a blank page. ', e);
+    }
+}
+
+const loadUrl = async function (page, url, takeScreenshot) {
+    let stepName = null;
+    let domcontentloaded = false;
+
+    try {
+        stepName = new URL(url).hostname;
+    } catch (e) {
+        const errorString = `Error parsing url: ${url}. ${e}`;
+        log.error(errorString);
+        /* If we fail to parse the URL, don't emit a metric with a stepName based on it.
+           It may not be a legal CloudWatch metric dimension name and we may not have an alarms
+           setup on the malformed URL stepName.  Instead, fail this step which will
+           show up in the logs and will fail the overall canary and alarm on the overall canary
+           success rate.
+        */
+        throw e;
+    }
+
+    await synthetics.executeStep(stepName, async function () {
+        const sanitizedUrl = syntheticsLogHelper.getSanitizedUrl(url);
+
+        /* You can customize the wait condition here. For instance, using 'networkidle2' or 'networkidle0' to load page completely.
+           networkidle0: Navigation is successful when the page has had no network requests for half a second. This might never happen if page is constantly loading multiple resources.
+           networkidle2: Navigation is successful when the page has no more then 2 network requests for half a second.
+           domcontentloaded: It's fired as soon as the page DOM has been loaded, without waiting for resources to finish loading. If needed add explicit wait with await new Promise(r => setTimeout(r, milliseconds))
+        */
+        const response = await page.goto(url, { waitUntil: ['domcontentloaded'], timeout: 30000});
+        if (response) {
+            domcontentloaded = true;
+            const status = response.status();
+            const statusText = response.statusText();
+
+            logResponseString = `Response from url: ${sanitizedUrl}  Status: ${status}  Status Text: ${statusText}`;
+
+            //If the response status code is not a 2xx success code
+            if (response.status() < 200 || response.status() > 299) {
+                throw new Error(`Failed to load url: ${sanitizedUrl} ${response.status()} ${response.statusText()}`);
+            }
+        } else {
+            const logNoResponseString = `No response returned for url: ${sanitizedUrl}`;
+            log.error(logNoResponseString);
+            throw new Error(logNoResponseString);
+        }
+    });
+
+    // Wait for 15 seconds to let page load fully before taking screenshot.
+    if (domcontentloaded && takeScreenshot) {
+        await new Promise(r => setTimeout(r, 15000));
+        await synthetics.takeScreenshot(stepName, 'loaded');
+    }
+
+    // Reset page
+    await resetPage(page);
+};
+
+exports.handler = async () => {
+    return await loadBlueprint();
+};

--- a/infrastructure/lib/constructs/snsMonitor.ts
+++ b/infrastructure/lib/constructs/snsMonitor.ts
@@ -1,0 +1,116 @@
+import { Construct } from 'constructs';
+import { Alarm } from 'aws-cdk-lib/aws-cloudwatch';
+import * as cloudwatch from "aws-cdk-lib/aws-cloudwatch";
+import * as sns from "aws-cdk-lib/aws-sns";
+import * as subscriptions from "aws-cdk-lib/aws-sns-subscriptions";
+import * as actions from "aws-cdk-lib/aws-cloudwatch-actions";
+import { Canary } from 'aws-cdk-lib/aws-synthetics';
+import {OpenSearchLambda} from "./lambda";
+
+interface SnsMonitorsProps {
+    readonly region: string;
+    readonly accountId: string;
+    readonly stepFunctionSnsAlarms?: Array<{ alertName: string, stateMachineName: string }>;
+    readonly canaryAlarms?: Array<{ alertName: string, canary: Canary }>;
+    readonly alarmNameSpace: string;
+    readonly snsTopic: string;
+    readonly slackLambda: OpenSearchLambda;
+}
+
+export class SnsMonitors extends Construct {
+    private readonly region: string;
+    private readonly accountId: string;
+    private readonly stepFunctionSnsAlarms?: Array<{ alertName: string, stateMachineName: string }>;
+    private readonly canaryAlarms?: Array<{ alertName: string, canary: Canary }>;
+    private readonly alarmNameSpace: string;
+    private readonly snsTopic: string;
+    private readonly slackLambda: OpenSearchLambda;
+
+
+    constructor(scope: Construct, id: string, props: SnsMonitorsProps) {
+        super(scope, id);
+        this.region = props.region;
+        this.accountId = props.accountId;
+        this.stepFunctionSnsAlarms = props.stepFunctionSnsAlarms;
+        this.canaryAlarms = props.canaryAlarms;
+        this.alarmNameSpace = props.alarmNameSpace;
+        this.snsTopic = props.snsTopic;
+        this.slackLambda = props.slackLambda;
+
+        // The email_list for receiving alerts
+        let emailList: Array<string> = [
+            ''
+        ];
+
+        // Create alarms
+        const map: { [id: string]: any } = {};
+
+        if(this.stepFunctionSnsAlarms){
+            this.stepFunctionSnsAlarms.forEach(({ alertName, stateMachineName }) => {
+                const alarm = this.stepFunctionExecutionsFailed(alertName, stateMachineName);
+                map[alarm[1]] = alarm[0];
+            });
+        }
+
+        if(this.canaryAlarms){
+            this.canaryAlarms.forEach(({ alertName, canary }) => {
+                const alarm = this.canaryFailed(alertName, canary);
+                map[alarm[1]] = alarm[0];
+            });
+        }
+
+        // Create SNS topic for alarms to be sent to
+        const sns_topic = new sns.Topic(this, `OpenSearchMetrics-Alarm-${this.snsTopic}`, {
+            displayName: `OpenSearchMetrics-Alarm-${this.snsTopic}`
+        });
+
+        // Iterate map to create SNS topic and add alarms on it
+        Object.keys(map).map(key => {
+            // Connect the alarm to the SNS
+            map[key].addAlarmAction(new actions.SnsAction(sns_topic));
+        })
+
+        // Send email notification to the recipients
+        for (const email of emailList) {
+            sns_topic.addSubscription(new subscriptions.EmailSubscription(email));
+        }
+
+        // Send slack notification
+        sns_topic.addSubscription(new subscriptions.LambdaSubscription(this.slackLambda.lambda));
+    }
+
+    private stepFunctionExecutionsFailed(alertName: string, stateMachineName: string): [Alarm, string] {
+        const alarmObject = new cloudwatch.Alarm(this, `error_alarm_${alertName}`, {
+            metric: new cloudwatch.Metric({
+                namespace:  this.alarmNameSpace,
+                metricName: "ExecutionsFailed",
+                statistic: "Sum",
+                dimensionsMap: {
+                    StateMachineArn: `arn:aws:states:${this.region}:${this.accountId}:stateMachine:${stateMachineName}`
+                }
+            }),
+            threshold: 1,
+            evaluationPeriods: 1,
+            comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+            datapointsToAlarm: 1,
+            treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+            alarmDescription: "Detect SF execution failure",
+            alarmName: alertName,
+        });
+        return [alarmObject, alertName];
+    }
+
+    private canaryFailed(alertName: string, canary: Canary): [Alarm, string] {
+        const alarmObject = new cloudwatch.Alarm(this, `error_alarm_${alertName}`, {
+            metric: canary.metricSuccessPercent(),
+            threshold: 100,
+            evaluationPeriods: 1,
+            comparisonOperator: cloudwatch.ComparisonOperator.LESS_THAN_THRESHOLD,
+            datapointsToAlarm: 1,
+            treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+            alarmDescription: "Detect Canary failure",
+            alarmName: alertName,
+        });
+        return [alarmObject, alertName];
+    }
+}

--- a/infrastructure/lib/infrastructure-stack.ts
+++ b/infrastructure/lib/infrastructure-stack.ts
@@ -9,6 +9,7 @@ import {OpenSearchMetricsNginxReadonly} from "./stacks/opensearchNginxProxyReado
 import {ArnPrincipal} from "aws-cdk-lib/aws-iam";
 import {OpenSearchWAF} from "./stacks/waf";
 import {OpenSearchMetricsNginxCognito} from "./constructs/opensearchNginxProxyCognito";
+import {OpenSearchMetricsMonitoringStack} from "./stacks/monitoringDashboard";
 
 // import * as sqs from 'aws-cdk-lib/aws-sqs';
 export class InfrastructureStack extends Stack {
@@ -34,12 +35,20 @@ export class InfrastructureStack extends Stack {
       }
     });
 
-
     // Create OpenSearch Metrics Lambda setup
     const openSearchMetricsWorkflowStack = new OpenSearchMetricsWorkflowStack(app, 'OpenSearchMetrics-Workflow', {
       opensearchDomainStack: openSearchDomainStack, vpcStack: vpcStack, lambdaPackage: Project.LAMBDA_PACKAGE})
     openSearchMetricsWorkflowStack.node.addDependency(vpcStack, openSearchDomainStack);
 
+    // Create Monitoring Dashboard
+
+    const openSearchMetricsMonitoringStack = new OpenSearchMetricsMonitoringStack(app, "OpenSearchMetrics-Monitoring", {
+      region: Project.REGION,
+      account: Project.AWS_ACCOUNT,
+      workflowComponent: openSearchMetricsWorkflowStack.workflowComponent,
+      lambdaPackage: Project.LAMBDA_PACKAGE
+    })
+    openSearchMetricsMonitoringStack.node.addDependency(openSearchMetricsWorkflowStack);
 
     // Create OpenSearch Metrics Frontend DNS
     const metricsHostedZone = new OpenSearchHealthRoute53(app, "OpenSearchMetrics-HostedZone", {

--- a/infrastructure/lib/stacks/metricsWorkflow.ts
+++ b/infrastructure/lib/stacks/metricsWorkflow.ts
@@ -13,7 +13,12 @@ export interface OpenSearchMetricsStackProps extends StackProps {
     readonly vpcStack: VpcStack;
     readonly lambdaPackage: string
 }
+
+export interface WorkflowComponent {
+    opensearchMetricsWorkflowStateMachineName: string
+}
 export class OpenSearchMetricsWorkflowStack extends Stack {
+    public readonly workflowComponent: WorkflowComponent;
     constructor(scope: Construct, id: string, props: OpenSearchMetricsStackProps) {
         super(scope, id, props);
 
@@ -39,6 +44,10 @@ export class OpenSearchMetricsWorkflowStack extends Stack {
             schedule: Schedule.expression('cron(0 7 * * ? *)'),
             targets: [new SfnStateMachine(opensearchMetricsWorkflow)],
         });
+
+        this.workflowComponent = {
+            opensearchMetricsWorkflowStateMachineName: opensearchMetricsWorkflow.stateMachineName
+        }
     }
 
     private createMetricsTask(scope: Construct, opensearchDomainStack: OpenSearchDomainStack,

--- a/infrastructure/lib/stacks/monitoringDashboard.ts
+++ b/infrastructure/lib/stacks/monitoringDashboard.ts
@@ -1,0 +1,91 @@
+import {Duration, Stack, StackProps} from "aws-cdk-lib";
+import { Construct } from 'constructs';
+import { WorkflowComponent } from "./metricsWorkflow";
+import { SnsMonitors } from "../constructs/snsMonitor";
+import {OpenSearchLambda} from "../constructs/lambda";
+import * as synthetics from "aws-cdk-lib/aws-synthetics";
+import * as path from "path";
+import * as secretsmanager from 'aws-cdk-lib/aws-secretsmanager';
+import Project from "../enums/project";
+
+interface OpenSearchMetricsMonitoringStackProps extends StackProps {
+    readonly region: string;
+    readonly account: string;
+    readonly workflowComponent: WorkflowComponent;
+    readonly lambdaPackage: string;
+}
+
+export class OpenSearchMetricsMonitoringStack extends Stack {
+
+    private readonly slackLambda: OpenSearchLambda;
+
+    constructor(scope: Construct, id: string, readonly props: OpenSearchMetricsMonitoringStackProps) {
+        super(scope, id, props);
+
+        const secretsName = 'slack-creds';
+        const slackCredsSecrets = new secretsmanager.Secret(this, 'SlackApiCreds', {
+            secretName: secretsName,
+        });
+
+        this.slackLambda = new OpenSearchLambda(this, "OpenSearchMetricsSlackLambdaFunction", {
+            lambdaNameBase: "OpenSearchMetricsDashboardsSlackLambda",
+            handler: "org.opensearchmetrics.lambda.SlackLambda",
+            lambdaZipPath: `../../../build/distributions/${props.lambdaPackage}`,
+            environment: {
+                SLACK_CREDENTIALS_SECRETS: secretsName,
+                SECRETS_MANAGER_REGION: slackCredsSecrets.env.region
+            }
+        });
+        this.snsMonitorStepFunctionExecutionsFailed();
+        this.snsMonitorCanaryFailed('metrics_heartbeat', `https://${Project.METRICS_HOSTED_ZONE}`);
+    }
+
+    /**
+     * Create SNS alarms for failure StepFunction jobs.
+     */
+    private snsMonitorStepFunctionExecutionsFailed(): void {
+        const stepFunctionSnsAlarms = [
+            { alertName: 'StepFunction_execution_errors_MetricsWorkflow', stateMachineName: this.props.workflowComponent.opensearchMetricsWorkflowStateMachineName },
+        ];
+
+        new SnsMonitors(this, "SnsMonitors-StepFunctionExecutionsFailed", {
+            region: this.props.region,
+            accountId: this.props.account,
+            stepFunctionSnsAlarms: stepFunctionSnsAlarms,
+            alarmNameSpace: "AWS/States",
+            snsTopic: "StepFunctionExecutionsFailed",
+            slackLambda: this.slackLambda
+        });
+    }
+
+    /**
+     * Create SNS alarms for failure Canaries.
+     */
+    private snsMonitorCanaryFailed(canaryName: string, canaryUrl: string): void {
+        const canary = new synthetics.Canary(this, 'CanaryHeartbeatMonitor', {
+            canaryName: canaryName,
+            schedule: synthetics.Schedule.rate(Duration.minutes(1)),
+            test: synthetics.Test.custom({
+                code: synthetics.Code.fromAsset(path.join(__dirname, '../../canary')),
+                handler: 'index.handler',
+            }),
+            runtime: synthetics.Runtime.SYNTHETICS_NODEJS_PUPPETEER_6_2,
+            environmentVariables: {
+                SITE_URL: canaryUrl
+            }
+        });
+
+        const canaryAlarms = [
+            { alertName: 'Canary_failed_MetricsWorkflow', canary: canary },
+        ];
+
+        new SnsMonitors(this, "SnsMonitors-CanaryFailed", {
+            region: this.props.region,
+            accountId: this.props.account,
+            canaryAlarms: canaryAlarms,
+            alarmNameSpace: "CloudWatchSynthetics",
+            snsTopic: "CanaryFailed",
+            slackLambda: this.slackLambda
+        });
+    }
+}

--- a/src/main/java/org/opensearchmetrics/dagger/CommonModule.java
+++ b/src/main/java/org/opensearchmetrics/dagger/CommonModule.java
@@ -30,6 +30,7 @@ public class CommonModule {
     private static final String OPENSEARCH_DOMAIN_REGION = "OPENSEARCH_DOMAIN_REGION";
     private static final String OPENSEARCH_DOMAIN_ROLE = "OPENSEARCH_DOMAIN_ROLE";
     private static final String ROLE_SESSION_NAME = "OpenSearchHealth";
+    private static final String SECRETS_MANAGER_REGION = "SECRETS_MANAGER_REGION";
 
     @Singleton
     @Provides
@@ -91,5 +92,15 @@ public class CommonModule {
                 issueComments, pullComments,
                 issuePositiveReactions, issueNegativeReactions,
                 labelMetrics, releaseMetrics);
+    }
+
+    @Provides
+    @Singleton
+    public SecretsManagerUtil getSecretsManagerUtil(ObjectMapper mapper) {
+        final String region = System.getenv(SECRETS_MANAGER_REGION);
+        final AWSSecretsManager secretsManager = AWSSecretsManagerClientBuilder.standard()
+                .withRegion(region)
+                .build();
+        return new SecretsManagerUtil(secretsManager, mapper);
     }
 }

--- a/src/main/java/org/opensearchmetrics/datasource/DataSourceType.java
+++ b/src/main/java/org/opensearchmetrics/datasource/DataSourceType.java
@@ -1,0 +1,7 @@
+package com.amazon.opensearchmetrics.datasource;
+
+public enum DataSourceType {
+    SLACK_WEBHOOK_URL,
+    SLACK_CHANNEL,
+    SLACK_USERNAME
+}

--- a/src/main/java/org/opensearchmetrics/lambda/SlackLambda.java
+++ b/src/main/java/org/opensearchmetrics/lambda/SlackLambda.java
@@ -1,0 +1,58 @@
+package org.opensearchmetrics.lambda;
+
+import com.amazon.opensearchmetrics.util.SecretsManagerUtil;
+import com.amazon.opensearchmetrics.datasource.DataSourceType;
+import lombok.extern.slf4j.Slf4j;
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.amazonaws.services.lambda.runtime.events.SNSEvent;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+
+import java.io.IOException;
+
+@Slf4j
+public class SlackLambda implements RequestHandler<SNSEvent, Void> {
+    try {
+        private static final String SLACK_WEBHOOK_URL = secretsManagerUtil.getSlackCredentials(DataSourceType.SLACK_WEBHOOK_URL).get();
+        private static final String SLACK_CHANNEL = secretsManagerUtil.getSlackCredentials(DataSourceType.SLACK_CHANNEL).get();
+        private static final String SLACK_USERNAME = secretsManagerUtil.getSlackCredentials(DataSourceType.SLACK_USERNAME).get();
+    } catch (Exception ex) {
+        log.info("Unable to get Slack credentials", ex);
+    }
+
+    @Override
+    public Void handleRequest(SNSEvent event, Context context) {
+        String message = event.getRecords().get(0).getSNS().getMessage();
+        sendMessageToSlack(message);
+        return null;
+    }
+
+    private void sendMessageToSlack(String message) {
+        ObjectMapper objectMapper = new ObjectMapper();
+        ObjectNode payload = objectMapper.createObjectNode();
+        payload.put("channel", SLACK_CHANNEL);
+        payload.put("username", SLACK_USERNAME);
+        payload.put("Content", message);
+        payload.put("icon_emoji", "");
+
+        try (CloseableHttpClient httpClient = HttpClientBuilder.create().build()) {
+            HttpPost httpPost = new HttpPost(SLACK_WEBHOOK_URL);
+            httpPost.setEntity(new StringEntity(objectMapper.writeValueAsString(payload), "UTF-8"));
+            HttpResponse response = httpClient.execute(httpPost);
+
+            System.out.println("{" +
+                    "\"message\": \"" + message + "\"," +
+                    "\"status_code\": " + response.getStatusLine().getStatusCode() + "," +
+                    "\"response\": \"" + response.getEntity().getContent().toString() + "\"" +
+                    "}");
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/main/java/org/opensearchmetrics/util/SecretsManagerUtil.java
+++ b/src/main/java/org/opensearchmetrics/util/SecretsManagerUtil.java
@@ -1,0 +1,62 @@
+package com.amazon.opensearchmetrics.util;
+
+import com.amazon.opensearchmetrics.datasource.DataSourceType;
+import com.amazonaws.services.secretsmanager.AWSSecretsManager;
+import com.amazonaws.services.secretsmanager.model.GetSecretValueRequest;
+import com.amazonaws.services.secretsmanager.model.GetSecretValueResult;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.auth.oauth2.GoogleCredentials;
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+
+@Slf4j
+public class SecretsManagerUtil {
+    private static final String SLACK_CREDENTIALS_SECRETS = "SLACK_CREDENTIALS_SECRETS";
+    private final AWSSecretsManager secretsManager;
+    private final ObjectMapper mapper;
+
+    public SecretsManagerUtil(AWSSecretsManager secretsManager, ObjectMapper mapper) {
+        this.secretsManager = secretsManager;
+        this.mapper = mapper;
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @Data
+    private static class SlackCredentials {
+        @JsonProperty("slackWebhookURL")
+        private String slackWebhookURL;
+        @JsonProperty("slackWebhookChannel")
+        private String slackWebhookChannel;
+        @JsonProperty("slackWebhookUsername")
+        private String slackWebhookUsername;
+    }
+    public Optional<String> getSlackCredentials(DataSourceType datasourceType) throws IOException {
+        String secretName = System.getenv(SLACK_CREDENTIALS_SECRETS);
+        log.info("Retrieving secrets value from secrets = {} ", secretName);
+        GetSecretValueResult getSecretValueResult =
+                secretsManager.getSecretValue(new GetSecretValueRequest().withSecretId(secretName));
+        log.info("Successfully retrieved secrets for data source credentials");
+        SlackCredentials credentials =
+                mapper.readValue(getSecretValueResult.getSecretString(), SlackCredentials.class);
+        switch (datasourceType) {
+            case SLACK:
+                return Optional.of(credentials.getSlackWebhookURL());
+            case SLACK_CHANNEL:
+                return Optional.of(credentials.getSlackWebhookChannel());
+            case SLACK_USERNAME:
+                return Optional.of(credentials.getSlackWebhookUsername());
+            default:
+                return Optional.empty();
+        }
+    }
+}


### PR DESCRIPTION
… integration

### Description
Creates a Cloudwatch Synthetic Canary to monitor the `metrics.opensearch.org` url and monitors the step functions for failure. If either of these fail, a message will be published to SNS, and will send email and slack notifications.

### Issues Resolved

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
