### PR TITLE
Added click UI tests to Canary URL monitoring

### DIFF
--- a/infrastructure/canary/nodejs/node_modules/urlMonitor.js
+++ b/infrastructure/canary/nodejs/node_modules/urlMonitor.js
@@ -68,7 +68,18 @@ const loadUrl = async function (page, url, takeScreenshot) {
            networkidle2: Navigation is successful when the page has no more then 2 network requests for half a second.
            domcontentloaded: It's fired as soon as the page DOM has been loaded, without waiting for resources to finish loading. If needed add explicit wait with await new Promise(r => setTimeout(r, milliseconds))
         */
-        const response = await page.goto(url, { waitUntil: ['domcontentloaded'], timeout: 30000});
+
+        const response = await page.goto(url, { waitUntil: ['load', 'networkidle0'], timeout: 30000});
+
+        await page.click('[aria-label="Closes this modal window"]');
+        await new Promise(r => setTimeout(r, 3000));
+        await page.click('button[aria-label="Toggle primary navigation"]');
+        await new Promise(r => setTimeout(r, 3000));
+        await Promise.all([
+            page.waitForNavigation(),
+            page.click('div[data-test-subj="collapsibleNavGroup-opensearchDashboards"] span[title="Dashboards"]'),
+        ]);
+
         if (response) {
             domcontentloaded = true;
             const status = response.status();
@@ -80,6 +91,7 @@ const loadUrl = async function (page, url, takeScreenshot) {
             if (response.status() < 200 || response.status() > 299) {
                 throw new Error(`Failed to load url: ${sanitizedUrl} ${response.status()} ${response.statusText()}`);
             }
+
         } else {
             const logNoResponseString = `No response returned for url: ${sanitizedUrl}`;
             log.error(logNoResponseString);
@@ -87,9 +99,9 @@ const loadUrl = async function (page, url, takeScreenshot) {
         }
     });
 
-    // Wait for 15 seconds to let page load fully before taking screenshot.
+    // Wait for 5 seconds to let page load fully before taking screenshot.
     if (domcontentloaded && takeScreenshot) {
-        await new Promise(r => setTimeout(r, 15000));
+        await new Promise(r => setTimeout(r, 5000));
         await synthetics.takeScreenshot(stepName, 'loaded');
     }
 

--- a/infrastructure/test/monitoring-stack.test.ts
+++ b/infrastructure/test/monitoring-stack.test.ts
@@ -164,8 +164,7 @@ test('Monitoring Stack Test', () => {
             "Handler": "urlMonitor.handler",
             "S3Bucket": {
                 "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
-            },
-            "S3Key": "3add60a2b13650e2ad0c97ef8b24082c52ea91e59b8b8bac89874c602a6b908d.zip"
+            }
         },
         "ExecutionRoleArn": {
             "Fn::GetAtt": [


### PR DESCRIPTION
### Description
Added click tests to the Canary script that tests if OpenSearch Dashboards is accessible to test the UI and make sure the dashboard is working.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
