### PR TITLE
Adding docker log to cloudwatch functionality

### DIFF
--- a/infrastructure/lib/constructs/canarySns.ts
+++ b/infrastructure/lib/constructs/canarySns.ts
@@ -26,12 +26,12 @@ export class canarySns extends SnsMonitors {
     private canaryFailed(alertName: string, canary: Canary): [Alarm, string] {
         const alarmObject = new cloudwatch.Alarm(this, `error_alarm_${alertName}`, {
             metric: canary.metricSuccessPercent({
-                period: Duration.minutes(5)
+                period: Duration.minutes(15)
             }),
-            threshold: 100,
-            evaluationPeriods: 3,
-            comparisonOperator: cloudwatch.ComparisonOperator.LESS_THAN_THRESHOLD,
-            datapointsToAlarm: 3,
+            threshold: 0,
+            evaluationPeriods: 1,
+            comparisonOperator: cloudwatch.ComparisonOperator.LESS_THAN_OR_EQUAL_TO_THRESHOLD,
+            datapointsToAlarm: 1,
             treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
             alarmDescription: "Detect Canary failure",
             alarmName: alertName,

--- a/infrastructure/lib/constructs/canarySns.ts
+++ b/infrastructure/lib/constructs/canarySns.ts
@@ -4,6 +4,7 @@ import {Construct} from "constructs";
 import {Alarm} from "aws-cdk-lib/aws-cloudwatch";
 import { Canary } from 'aws-cdk-lib/aws-synthetics';
 import * as cloudwatch from "aws-cdk-lib/aws-cloudwatch";
+import {Duration} from "aws-cdk-lib";
 
 interface canarySnsProps extends SnsMonitorsProps {
     readonly canaryAlarms: Array<{ alertName: string, canary: Canary }>;
@@ -24,11 +25,13 @@ export class canarySns extends SnsMonitors {
 
     private canaryFailed(alertName: string, canary: Canary): [Alarm, string] {
         const alarmObject = new cloudwatch.Alarm(this, `error_alarm_${alertName}`, {
-            metric: canary.metricSuccessPercent(),
-            threshold: 50,
-            evaluationPeriods: 1,
+            metric: canary.metricSuccessPercent({
+                period: Duration.minutes(5)
+            }),
+            threshold: 100,
+            evaluationPeriods: 3,
             comparisonOperator: cloudwatch.ComparisonOperator.LESS_THAN_THRESHOLD,
-            datapointsToAlarm: 1,
+            datapointsToAlarm: 3,
             treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
             alarmDescription: "Detect Canary failure",
             alarmName: alertName,

--- a/infrastructure/test/monitoring-stack.test.ts
+++ b/infrastructure/test/monitoring-stack.test.ts
@@ -211,7 +211,7 @@ test('Monitoring Stack Test', () => {
         ],
         "AlarmDescription": "Detect Canary failure",
         "AlarmName": "Canary_failed_MetricsWorkflow",
-        "ComparisonOperator": "LessThanThreshold",
+        "ComparisonOperator": "LessThanOrEqualToThreshold",
         "DatapointsToAlarm": 1,
         "Dimensions": [
             {
@@ -224,9 +224,9 @@ test('Monitoring Stack Test', () => {
         "EvaluationPeriods": 1,
         "MetricName": "SuccessPercent",
         "Namespace": "CloudWatchSynthetics",
-        "Period": 300,
+        "Period": 900,
         "Statistic": "Average",
-        "Threshold": 50,
+        "Threshold": 0,
         "TreatMissingData": "notBreaching"
     });
 });

--- a/infrastructure/test/opensearch-stack.test.ts
+++ b/infrastructure/test/opensearch-stack.test.ts
@@ -7,10 +7,10 @@ import {VpcStack} from "../lib/stacks/vpc";
 
 test('OpenSearchDomain Stack Test', () => {
     const app = new App();
-    const openSearchDomainStack = new OpenSearchDomainStack(app, 'Test-OpenSearchHealth-OpenSearch', {
+    const openSearchDomainStack = new OpenSearchDomainStack(app, 'OpenSearchHealth-OpenSearch', {
         region: "us-east-1",
         account: "test-account",
-        vpcStack: new VpcStack(app, 'Test-OpenSearchHealth-VPC', {}),
+        vpcStack: new VpcStack(app, 'OpenSearchHealth-VPC', {}),
         enableNginxCognito: true,
         jenkinsAccess: {
             jenkinsAccountRoles:  [
@@ -93,5 +93,132 @@ test('OpenSearchDomain Stack Test', () => {
                 "Ref": "UserPool"
             }
         }
+    });
+
+    openSearchDomainStackTemplate.resourceCountIs('AWS::Route53::RecordSet', 1);
+    openSearchDomainStackTemplate.hasResourceProperties('AWS::Route53::RecordSet', {
+        "Name": `${Project.METRICS_COGNITO_HOSTED_ZONE}.`,
+        "Type": "A"
+    });
+
+    openSearchDomainStackTemplate.resourceCountIs('AWS::AutoScaling::LaunchConfiguration', 1);
+    openSearchDomainStackTemplate.resourceCountIs('AWS::EC2::SecurityGroup', 2);
+    openSearchDomainStackTemplate.hasResourceProperties('AWS::EC2::SecurityGroup', {
+        "SecurityGroupEgress": [
+            {
+                "CidrIp": "0.0.0.0/0",
+                "Description": "Allow all outbound traffic by default",
+                "IpProtocol": "-1"
+            }
+        ]
+    });
+    openSearchDomainStackTemplate.hasResourceProperties('AWS::EC2::SecurityGroup', {
+        "SecurityGroupIngress": [
+            {
+                "CidrIp": "0.0.0.0/0",
+                "Description": "Allow from anyone on port 443",
+                "FromPort": 443,
+                "IpProtocol": "tcp",
+                "ToPort": 443
+            }
+        ]
+    });
+    openSearchDomainStackTemplate.hasResourceProperties('AWS::IAM::Role', {
+        "AssumeRolePolicyDocument": {
+            "Statement": [
+                {
+                    "Action": "sts:AssumeRole",
+                    "Effect": "Allow",
+                    "Principal": {
+                        "Service": "ec2.amazonaws.com"
+                    }
+                }
+            ],
+            "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+            {
+                "Fn::Join": [
+                    "",
+                    [
+                        "arn:",
+                        {
+                            "Ref": "AWS::Partition"
+                        },
+                        ":iam::aws:policy/AmazonSSMManagedInstanceCore"
+                    ]
+                ]
+            }
+        ],
+        "RoleName": "OpenSearchCognitoUserAccess"
+    })
+    openSearchDomainStackTemplate.resourceCountIs('AWS::ElasticLoadBalancingV2::LoadBalancer', 1);
+    openSearchDomainStackTemplate.hasResourceProperties('AWS::ElasticLoadBalancingV2::LoadBalancer', {
+        "LoadBalancerAttributes": [
+            {
+                "Key": "deletion_protection.enabled",
+                "Value": "false"
+            }
+        ],
+        "Scheme": "internet-facing",
+        "Type": "application"
+    });
+    openSearchDomainStackTemplate.resourceCountIs('AWS::ElasticLoadBalancingV2::Listener', 1);
+    openSearchDomainStackTemplate.hasResourceProperties('AWS::ElasticLoadBalancingV2::Listener', {
+        "Port": 443,
+        "Protocol": "HTTPS"
+    });
+    openSearchDomainStackTemplate.resourceCountIs('AWS::ElasticLoadBalancingV2::TargetGroup', 1);
+    openSearchDomainStackTemplate.hasResourceProperties('AWS::ElasticLoadBalancingV2::TargetGroup', {
+        "HealthCheckPath": "/",
+        "HealthCheckPort": "80",
+        "Port": 443,
+        "Protocol": "HTTPS",
+        "TargetGroupAttributes": [
+            {
+                "Key": "stickiness.enabled",
+                "Value": "false"
+            }
+        ],
+        "TargetType": "instance",
+        "VpcId": {
+            "Fn::ImportValue": "OpenSearchHealth-VPC:ExportsOutputRefOpenSearchHealthVpcB885AABED860B3EB"
+        }
+    });
+    openSearchDomainStackTemplate.resourceCountIs('AWS::AutoScaling::AutoScalingGroup', 1);
+    openSearchDomainStackTemplate.hasResourceProperties('AWS::AutoScaling::AutoScalingGroup', {
+        "DesiredCapacity": "1",
+        "HealthCheckGracePeriod": 90,
+        "HealthCheckType": "EC2",
+        "LaunchConfigurationName": {
+            "Ref": "OpenSearchMetricsNginxOpenSearchMetricsCognitoMetricsProxyAsgLaunchConfig8D060946"
+        },
+        "MaxSize": "1",
+        "MinSize": "1",
+        "Tags": [
+            {
+                "Key": "name",
+                "PropagateAtLaunch": true,
+                "Value": "OpenSearchMetricsCognito-NginxProxyHost"
+            },
+            {
+                "Key": "Name",
+                "PropagateAtLaunch": true,
+                "Value": "OpenSearchMetricsCognito"
+            }
+        ],
+        "TargetGroupARNs": [
+            {
+                "Ref": "OpenSearchMetricsNginxOpenSearchMetricsCognitoNginxProxyAlbOpenSearchMetricsCognitoNginxProxyAlbListenerOpenSearchMetricsCognitoNginxProxyAlbTargetGroup8E449B4A"
+            }
+        ],
+        "VPCZoneIdentifier": [
+            {
+                "Fn::ImportValue": "OpenSearchHealth-VPC:ExportsOutputRefOpenSearchHealthVpcPrivateSubnet1Subnet529349B600974078"
+            },
+            {
+                "Fn::ImportValue": "OpenSearchHealth-VPC:ExportsOutputRefOpenSearchHealthVpcPrivateSubnet2SubnetBA599EDB2BEEEA30"
+            }
+        ]
     });
 });


### PR DESCRIPTION
### Description

1. Changes docker log driver to awslogs so docker can push logs to cloudwatch.
2. Tuned canary alarm settings

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

https://github.com/opensearch-project/opensearch-metrics/issues/47

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
