### PR TITLE
Reverted adding 1.3.18 to ReleaseInputs

### DIFF
--- a/src/main/java/org/opensearchmetrics/metrics/release/ReleaseInputs.java
+++ b/src/main/java/org/opensearchmetrics/metrics/release/ReleaseInputs.java
@@ -9,8 +9,7 @@ public enum ReleaseInputs {
     VERSION_2_16_0("2.16.0", "open", "2.x"),
     VERSION_1_3_15("1.3.15", "closed", "1.3"),
     VERSION_1_3_16("1.3.16", "closed", "1.3"),
-    VERSION_1_3_17("1.3.17", "closed", "1.3"),
-    VERSION_1_3_18("1.3.18", "open", "1.3");
+    VERSION_1_3_17("1.3.17", "closed", "1.3");
 
     private final String version;
     private final String state;

--- a/src/test/java/org/opensearchmetrics/metrics/release/ReleaseInputsTest.java
+++ b/src/test/java/org/opensearchmetrics/metrics/release/ReleaseInputsTest.java
@@ -18,7 +18,6 @@ public class ReleaseInputsTest {
         assertEquals("1.3.15", ReleaseInputs.VERSION_1_3_15.getVersion());
         assertEquals("1.3.16", ReleaseInputs.VERSION_1_3_16.getVersion());
         assertEquals("1.3.17", ReleaseInputs.VERSION_1_3_17.getVersion());
-        assertEquals("1.3.18", ReleaseInputs.VERSION_1_3_18.getVersion());
     }
 
     @Test
@@ -32,7 +31,6 @@ public class ReleaseInputsTest {
         assertEquals("closed", ReleaseInputs.VERSION_1_3_15.getState());
         assertEquals("closed", ReleaseInputs.VERSION_1_3_16.getState());
         assertEquals("closed", ReleaseInputs.VERSION_1_3_17.getState());
-        assertEquals("open", ReleaseInputs.VERSION_1_3_18.getState());
     }
 
     @Test
@@ -46,13 +44,12 @@ public class ReleaseInputsTest {
         assertEquals("1.3", ReleaseInputs.VERSION_1_3_15.getBranch());
         assertEquals("1.3", ReleaseInputs.VERSION_1_3_16.getBranch());
         assertEquals("1.3", ReleaseInputs.VERSION_1_3_17.getBranch());
-        assertEquals("1.3", ReleaseInputs.VERSION_1_3_18.getBranch());
     }
 
     @Test
     public void testGetAllReleaseInputs() {
         ReleaseInputs[] releaseInputs = ReleaseInputs.getAllReleaseInputs();
-        assertEquals(10, releaseInputs.length);
+        assertEquals(9, releaseInputs.length);
         assertEquals(ReleaseInputs.VERSION_3_0_0, releaseInputs[0]);
         assertEquals(ReleaseInputs.VERSION_2_12_0, releaseInputs[1]);
         assertEquals(ReleaseInputs.VERSION_2_13_0, releaseInputs[2]);
@@ -62,6 +59,5 @@ public class ReleaseInputsTest {
         assertEquals(ReleaseInputs.VERSION_1_3_15, releaseInputs[6]);
         assertEquals(ReleaseInputs.VERSION_1_3_16, releaseInputs[7]);
         assertEquals(ReleaseInputs.VERSION_1_3_17, releaseInputs[8]);
-        assertEquals(ReleaseInputs.VERSION_1_3_18, releaseInputs[9]);
     }
 }


### PR DESCRIPTION
### Description

Reverted adding 1.3.18 to ReleaseInputs

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
