### PR TITLE
Upgrade typescript, format the code and add license header

### DIFF
--- a/infrastructure/canary/nodejs/node_modules/urlMonitor.js
+++ b/infrastructure/canary/nodejs/node_modules/urlMonitor.js
@@ -1,3 +1,11 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
 const { URL } = require('url');
 const synthetics = require('Synthetics');
 const log = require('SyntheticsLogger');
@@ -34,9 +42,9 @@ const loadBlueprint = async function () {
 };
 
 // Reset the page in-between
-const resetPage = async function(page) {
+const resetPage = async function (page) {
     try {
-        await page.goto('about:blank',{waitUntil: ['load', 'networkidle0'], timeout: 30000} );
+        await page.goto('about:blank', { waitUntil: ['load', 'networkidle0'], timeout: 30000 });
     } catch (e) {
         synthetics.addExecutionError('Unable to open a blank page. ', e);
     }
@@ -69,7 +77,7 @@ const loadUrl = async function (page, url, takeScreenshot) {
            domcontentloaded: It's fired as soon as the page DOM has been loaded, without waiting for resources to finish loading. If needed add explicit wait with await new Promise(r => setTimeout(r, milliseconds))
         */
 
-        const response = await page.goto(url, { waitUntil: ['load', 'networkidle0'], timeout: 30000});
+        const response = await page.goto(url, { waitUntil: ['load', 'networkidle0'], timeout: 30000 });
 
         await page.click('[aria-label="Closes this modal window"]');
         await new Promise(r => setTimeout(r, 3000));

--- a/infrastructure/lib/constructs/canarySns.ts
+++ b/infrastructure/lib/constructs/canarySns.ts
@@ -1,10 +1,17 @@
-import {SnsMonitors} from "./snsMonitor";
-import {SnsMonitorsProps} from "./snsMonitor";
-import {Construct} from "constructs";
-import {Alarm} from "aws-cdk-lib/aws-cloudwatch";
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+import { SnsMonitors } from "./snsMonitor";
+import { SnsMonitorsProps } from "./snsMonitor";
+import { Construct } from "constructs";
+import { Alarm, ComparisonOperator, TreatMissingData } from "aws-cdk-lib/aws-cloudwatch";
 import { Canary } from 'aws-cdk-lib/aws-synthetics';
-import * as cloudwatch from "aws-cdk-lib/aws-cloudwatch";
-import {Duration} from "aws-cdk-lib";
+import { Duration } from "aws-cdk-lib";
 
 interface canarySnsProps extends SnsMonitorsProps {
     readonly canaryAlarms: Array<{ alertName: string, canary: Canary }>;
@@ -15,8 +22,7 @@ export class canarySns extends SnsMonitors {
     constructor(scope: Construct, id: string, props: canarySnsProps) {
         super(scope, id, props);
         this.canaryAlarms = props.canaryAlarms;
-        this.canaryAlarms.forEach(({ alertName, canary }) =>
-        {
+        this.canaryAlarms.forEach(({ alertName, canary }) => {
             const alarm = this.canaryFailed(alertName, canary);
             this.map[alarm[1]] = alarm[0];
         });
@@ -24,15 +30,15 @@ export class canarySns extends SnsMonitors {
     }
 
     private canaryFailed(alertName: string, canary: Canary): [Alarm, string] {
-        const alarmObject = new cloudwatch.Alarm(this, `error_alarm_${alertName}`, {
+        const alarmObject = new Alarm(this, `error_alarm_${alertName}`, {
             metric: canary.metricSuccessPercent({
                 period: Duration.minutes(15)
             }),
             threshold: 0,
             evaluationPeriods: 1,
-            comparisonOperator: cloudwatch.ComparisonOperator.LESS_THAN_OR_EQUAL_TO_THRESHOLD,
+            comparisonOperator: ComparisonOperator.LESS_THAN_OR_EQUAL_TO_THRESHOLD,
             datapointsToAlarm: 1,
-            treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+            treatMissingData: TreatMissingData.NOT_BREACHING,
             alarmDescription: "Detect Canary failure",
             alarmName: alertName,
         });

--- a/infrastructure/lib/constructs/lambda.ts
+++ b/infrastructure/lib/constructs/lambda.ts
@@ -1,9 +1,17 @@
-import {Code, Function, Runtime, Tracing} from 'aws-cdk-lib/aws-lambda';
-import * as path from 'path';
-import {Duration, Stack} from 'aws-cdk-lib';
-import { Construct } from 'constructs';
-import {ISecurityGroup, IVpc, SubnetType} from "aws-cdk-lib/aws-ec2";
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+import { Duration } from 'aws-cdk-lib';
+import { ISecurityGroup, IVpc, SubnetType } from "aws-cdk-lib/aws-ec2";
 import { IRole } from "aws-cdk-lib/aws-iam";
+import { Code, Function, Runtime, Tracing } from 'aws-cdk-lib/aws-lambda';
+import { Construct } from 'constructs';
+import * as path from 'path';
 
 export class OpenSearchLambdaProps {
     readonly lambdaNameBase: string;
@@ -27,7 +35,8 @@ export class OpenSearchLambda extends Construct {
         this.lambda = new Function(scope, `${props.lambdaNameBase}Lambda`, {
             vpc: props.vpc,
             vpcSubnets: props.vpc?.selectSubnets({
-                subnetType: SubnetType.PRIVATE_WITH_EGRESS}),
+                subnetType: SubnetType.PRIVATE_WITH_EGRESS
+            }),
             securityGroups: props.securityGroup ? [props.securityGroup] : undefined,
             role: props.role ? props.role : undefined,
             code: Code.fromAsset(path.join(__dirname, props.lambdaZipPath)),

--- a/infrastructure/lib/constructs/opensearchNginxProxyCognito.ts
+++ b/infrastructure/lib/constructs/opensearchNginxProxyCognito.ts
@@ -1,32 +1,40 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+import { Aspects, CfnOutput, Duration, Tag, Tags } from 'aws-cdk-lib';
 import {
-    BlockDeviceVolume,
-    HealthCheck,
-    UpdatePolicy,
     AutoScalingGroup,
-    CfnLaunchConfiguration
+    BlockDeviceVolume,
+    CfnLaunchConfiguration,
+    HealthCheck,
+    UpdatePolicy
 } from 'aws-cdk-lib/aws-autoscaling';
 import {
     InstanceClass,
     InstanceSize,
     InstanceType,
+    MachineImage,
     Peer,
     Port,
     SecurityGroup,
     SubnetType,
-    Vpc,
-    MachineImage
+    Vpc
 } from 'aws-cdk-lib/aws-ec2';
-import { ManagedPolicy, Role, ServicePrincipal } from 'aws-cdk-lib/aws-iam';
-import {Aspects, CfnOutput, Duration, Tag, Tags} from 'aws-cdk-lib';
-import { Construct } from 'constructs';
 import {
     ApplicationLoadBalancer, ApplicationProtocol,
     ListenerCertificate, Protocol, SslPolicy,
 } from "aws-cdk-lib/aws-elasticloadbalancingv2";
+import { ManagedPolicy, Role, ServicePrincipal } from 'aws-cdk-lib/aws-iam';
+import { ARecord, RecordTarget } from "aws-cdk-lib/aws-route53";
+import { LoadBalancerTarget } from "aws-cdk-lib/aws-route53-targets";
+import { Construct } from 'constructs';
 import Project from "../enums/project";
-import {ARecord, RecordTarget} from "aws-cdk-lib/aws-route53";
-import {LoadBalancerTarget} from "aws-cdk-lib/aws-route53-targets";
-import {OpenSearchHealthRoute53} from "../stacks/route53";
+import { OpenSearchHealthRoute53 } from "../stacks/route53";
 
 
 export interface NginxProps {

--- a/infrastructure/lib/constructs/snsMonitor.ts
+++ b/infrastructure/lib/constructs/snsMonitor.ts
@@ -1,9 +1,17 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+import { SnsAction } from 'aws-cdk-lib/aws-cloudwatch-actions';
+import { Topic } from 'aws-cdk-lib/aws-sns';
+import { EmailSubscription, LambdaSubscription } from 'aws-cdk-lib/aws-sns-subscriptions';
 import { Construct } from 'constructs';
-import * as sns from "aws-cdk-lib/aws-sns";
-import * as subscriptions from "aws-cdk-lib/aws-sns-subscriptions";
-import * as actions from "aws-cdk-lib/aws-cloudwatch-actions";
-import {OpenSearchLambda} from "./lambda";
 import Project from '../enums/project';
+import { OpenSearchLambda } from "./lambda";
 
 
 export interface SnsMonitorsProps {
@@ -42,24 +50,24 @@ export class SnsMonitors extends Construct {
 
     }
 
-    protected createTopic(){
+    protected createTopic() {
         // Create SNS topic for alarms to be sent to
-        const snsTopic = new sns.Topic(this, `OpenSearchMetrics-Alarm-${this.snsTopicName}`, {
+        const snsTopic = new Topic(this, `OpenSearchMetrics-Alarm-${this.snsTopicName}`, {
             displayName: `OpenSearchMetrics-Alarm-${this.snsTopicName}`
         });
 
         // Iterate map to create SNS topic and add alarms on it
         Object.keys(this.map).map(key => {
             // Connect the alarm to the SNS
-            this.map[key].addAlarmAction(new actions.SnsAction(snsTopic));
+            this.map[key].addAlarmAction(new SnsAction(snsTopic));
         })
 
         // Send email notification to the recipients
         for (const email of this.emailList) {
-            snsTopic.addSubscription(new subscriptions.EmailSubscription(email));
+            snsTopic.addSubscription(new EmailSubscription(email));
         }
 
         // Send slack notification
-        snsTopic.addSubscription(new subscriptions.LambdaSubscription(this.slackLambda.lambda));
+        snsTopic.addSubscription(new LambdaSubscription(this.slackLambda.lambda));
     }
 }

--- a/infrastructure/lib/constructs/stepFunctionSns.ts
+++ b/infrastructure/lib/constructs/stepFunctionSns.ts
@@ -1,8 +1,14 @@
-import {SnsMonitors} from "./snsMonitor";
-import {SnsMonitorsProps} from "./snsMonitor";
-import {Construct} from "constructs";
-import {Alarm} from "aws-cdk-lib/aws-cloudwatch";
-import * as cloudwatch from "aws-cdk-lib/aws-cloudwatch";
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+import { Alarm, ComparisonOperator, Metric, TreatMissingData } from "aws-cdk-lib/aws-cloudwatch";
+import { Construct } from "constructs";
+import { SnsMonitors, SnsMonitorsProps } from "./snsMonitor";
 
 interface stepFunctionSnsProps extends SnsMonitorsProps {
     readonly stepFunctionSnsAlarms: Array<{ alertName: string, stateMachineName: string }>;
@@ -13,8 +19,7 @@ export class StepFunctionSns extends SnsMonitors {
     constructor(scope: Construct, id: string, props: stepFunctionSnsProps) {
         super(scope, id, props);
         this.stepFunctionSnsAlarms = props.stepFunctionSnsAlarms;
-        this.stepFunctionSnsAlarms.forEach(({ alertName, stateMachineName }) =>
-        {
+        this.stepFunctionSnsAlarms.forEach(({ alertName, stateMachineName }) => {
             const alarm = this.stepFunctionExecutionsFailed(alertName, stateMachineName);
             this.map[alarm[1]] = alarm[0];
         });
@@ -22,9 +27,9 @@ export class StepFunctionSns extends SnsMonitors {
     }
 
     private stepFunctionExecutionsFailed(alertName: string, stateMachineName: string): [Alarm, string] {
-        const alarmObject = new cloudwatch.Alarm(this, `error_alarm_${alertName}`, {
-            metric: new cloudwatch.Metric({
-                namespace:  this.alarmNameSpace,
+        const alarmObject = new Alarm(this, `error_alarm_${alertName}`, {
+            metric: new Metric({
+                namespace: this.alarmNameSpace,
                 metricName: "ExecutionsFailed",
                 statistic: "Sum",
                 dimensionsMap: {
@@ -33,9 +38,9 @@ export class StepFunctionSns extends SnsMonitors {
             }),
             threshold: 1,
             evaluationPeriods: 1,
-            comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+            comparisonOperator: ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
             datapointsToAlarm: 1,
-            treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+            treatMissingData: TreatMissingData.NOT_BREACHING,
             alarmDescription: "Detect SF execution failure",
             alarmName: alertName,
         });

--- a/infrastructure/lib/enums/project.ts
+++ b/infrastructure/lib/enums/project.ts
@@ -1,4 +1,12 @@
-enum Project{
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+enum Project {
     AWS_ACCOUNT = '',
     JENKINS_MASTER_ROLE = '',
     JENKINS_AGENT_ROLE = '',

--- a/infrastructure/lib/infrastructure-stack.ts
+++ b/infrastructure/lib/infrastructure-stack.ts
@@ -1,16 +1,24 @@
-import {App, Fn, Stack, StackProps} from 'aws-cdk-lib';
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+import { App, Fn, Stack, StackProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { VpcStack } from "./stacks/vpc";
-import {OpenSearchDomainStack} from "./stacks/opensearch";
+import { OpenSearchDomainStack } from "./stacks/opensearch";
 import Project from './enums/project';
-import {OpenSearchHealthRoute53} from "./stacks/route53";
-import {OpenSearchMetricsWorkflowStack} from "./stacks/metricsWorkflow";
-import {OpenSearchMetricsNginxReadonly} from "./stacks/opensearchNginxProxyReadonly";
-import {ArnPrincipal} from "aws-cdk-lib/aws-iam";
-import {OpenSearchWAF} from "./stacks/waf";
-import {OpenSearchMetricsNginxCognito} from "./constructs/opensearchNginxProxyCognito";
-import {OpenSearchMetricsMonitoringStack} from "./stacks/monitoringDashboard";
-import {OpenSearchMetricsSecretsStack} from "./stacks/secrets";
+import { OpenSearchHealthRoute53 } from "./stacks/route53";
+import { OpenSearchMetricsWorkflowStack } from "./stacks/metricsWorkflow";
+import { OpenSearchMetricsNginxReadonly } from "./stacks/opensearchNginxProxyReadonly";
+import { ArnPrincipal } from "aws-cdk-lib/aws-iam";
+import { OpenSearchWAF } from "./stacks/waf";
+import { OpenSearchMetricsNginxCognito } from "./constructs/opensearchNginxProxyCognito";
+import { OpenSearchMetricsMonitoringStack } from "./stacks/monitoringDashboard";
+import { OpenSearchMetricsSecretsStack } from "./stacks/secrets";
 
 // import * as sqs from 'aws-cdk-lib/aws-sqs';
 export class InfrastructureStack extends Stack {
@@ -29,7 +37,7 @@ export class InfrastructureStack extends Stack {
       vpcStack: vpcStack,
       enableNginxCognito: true,
       jenkinsAccess: {
-        jenkinsAccountRoles:  [
+        jenkinsAccountRoles: [
           new ArnPrincipal(Project.JENKINS_MASTER_ROLE),
           new ArnPrincipal(Project.JENKINS_AGENT_ROLE)
         ]
@@ -38,7 +46,8 @@ export class InfrastructureStack extends Stack {
 
     // Create OpenSearch Metrics Lambda setup
     const openSearchMetricsWorkflowStack = new OpenSearchMetricsWorkflowStack(app, 'OpenSearchMetrics-Workflow', {
-      opensearchDomainStack: openSearchDomainStack, vpcStack: vpcStack, lambdaPackage: Project.LAMBDA_PACKAGE})
+      opensearchDomainStack: openSearchDomainStack, vpcStack: vpcStack, lambdaPackage: Project.LAMBDA_PACKAGE
+    })
     openSearchMetricsWorkflowStack.node.addDependency(vpcStack, openSearchDomainStack);
 
     // Create Secrets Manager

--- a/infrastructure/lib/stacks/metricsWorkflow.ts
+++ b/infrastructure/lib/stacks/metricsWorkflow.ts
@@ -1,12 +1,20 @@
-import { OpenSearchDomainStack } from "./opensearch";
-import {OpenSearchLambda} from "../constructs/lambda";
-import {Duration, Stack, StackProps} from "aws-cdk-lib";
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+import { Duration, Stack, StackProps } from "aws-cdk-lib";
+import { Rule, Schedule } from "aws-cdk-lib/aws-events";
+import { SfnStateMachine } from "aws-cdk-lib/aws-events-targets";
+import { JsonPath, StateMachine } from "aws-cdk-lib/aws-stepfunctions";
+import { LambdaInvoke } from "aws-cdk-lib/aws-stepfunctions-tasks";
 import { Construct } from 'constructs';
+import { OpenSearchLambda } from "../constructs/lambda";
+import { OpenSearchDomainStack } from "./opensearch";
 import { VpcStack } from "./vpc";
-import {LambdaInvoke} from "aws-cdk-lib/aws-stepfunctions-tasks";
-import {JsonPath, StateMachine} from "aws-cdk-lib/aws-stepfunctions";
-import {Rule, Schedule} from "aws-cdk-lib/aws-events";
-import {SfnStateMachine} from "aws-cdk-lib/aws-events-targets";
 
 export interface OpenSearchMetricsStackProps extends StackProps {
     readonly opensearchDomainStack: OpenSearchDomainStack;
@@ -51,7 +59,7 @@ export class OpenSearchMetricsWorkflowStack extends Stack {
     }
 
     private createMetricsTask(scope: Construct, opensearchDomainStack: OpenSearchDomainStack,
-                             vpcStack: VpcStack, lambdaPackage: string) {
+        vpcStack: VpcStack, lambdaPackage: string) {
         const openSearchDomain = opensearchDomainStack.domain;
         const metricsLambda = new OpenSearchLambda(scope, "OpenSearchMetricsLambdaFunction", {
             lambdaNameBase: "OpenSearchMetricsDashboards",

--- a/infrastructure/lib/stacks/monitoringDashboard.ts
+++ b/infrastructure/lib/stacks/monitoringDashboard.ts
@@ -1,15 +1,23 @@
-import {Duration, Stack, StackProps} from "aws-cdk-lib";
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+import { Duration, Stack, StackProps } from "aws-cdk-lib";
+import { Effect, PolicyStatement, Role, ServicePrincipal } from "aws-cdk-lib/aws-iam";
+import { Secret } from "aws-cdk-lib/aws-secretsmanager";
+import { Canary, Code, Runtime, Schedule, Test } from "aws-cdk-lib/aws-synthetics";
 import { Construct } from 'constructs';
-import { WorkflowComponent } from "./metricsWorkflow";
-import {OpenSearchLambda} from "../constructs/lambda";
-import {Secret} from "aws-cdk-lib/aws-secretsmanager";
-import { VpcStack } from "./vpc";
-import { Runtime, Canary, Test, Code, Schedule } from "aws-cdk-lib/aws-synthetics";
 import * as path from "path";
+import { canarySns } from "../constructs/canarySns";
+import { OpenSearchLambda } from "../constructs/lambda";
+import { StepFunctionSns } from "../constructs/stepFunctionSns";
 import Project from "../enums/project";
-import {Effect, PolicyDocument, PolicyStatement, Role, ServicePrincipal} from "aws-cdk-lib/aws-iam";
-import {StepFunctionSns} from "../constructs/stepFunctionSns";
-import {canarySns} from "../constructs/canarySns";
+import { WorkflowComponent } from "./metricsWorkflow";
+import { VpcStack } from "./vpc";
 
 
 interface OpenSearchMetricsMonitoringStackProps extends StackProps {

--- a/infrastructure/lib/stacks/opensearchNginxProxyReadonly.ts
+++ b/infrastructure/lib/stacks/opensearchNginxProxyReadonly.ts
@@ -1,3 +1,12 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+import { Aspects, CfnOutput, Duration, Stack, Tag, Tags } from 'aws-cdk-lib';
 import {
     AutoScalingGroup,
     BlockDeviceVolume,
@@ -16,9 +25,6 @@ import {
     SubnetType,
     Vpc
 } from 'aws-cdk-lib/aws-ec2';
-import {Effect, ManagedPolicy, PolicyStatement, Role, ServicePrincipal} from "aws-cdk-lib/aws-iam";
-import {Aspects, CfnOutput, Duration, Stack, Tag, Tags} from 'aws-cdk-lib';
-import {Construct} from 'constructs';
 import {
     ApplicationLoadBalancer,
     ApplicationProtocol,
@@ -26,10 +32,12 @@ import {
     Protocol,
     SslPolicy,
 } from "aws-cdk-lib/aws-elasticloadbalancingv2";
+import { Effect, ManagedPolicy, PolicyStatement, Role, ServicePrincipal } from "aws-cdk-lib/aws-iam";
+import { ARecord, RecordTarget } from "aws-cdk-lib/aws-route53";
+import { LoadBalancerTarget } from "aws-cdk-lib/aws-route53-targets";
+import { Construct } from 'constructs';
 import Project from "../enums/project";
-import {OpenSearchHealthRoute53} from "./route53";
-import {ARecord, RecordTarget} from "aws-cdk-lib/aws-route53";
-import {LoadBalancerTarget} from "aws-cdk-lib/aws-route53-targets";
+import { OpenSearchHealthRoute53 } from "./route53";
 
 
 export interface NginxProps {
@@ -59,15 +67,15 @@ export class OpenSearchMetricsNginxReadonly extends Stack {
     readonly asg: AutoScalingGroup;
 
     constructor(scope: Construct, id: string, props: NginxProps) {
-        const {vpc, securityGroup} = props;
+        const { vpc, securityGroup } = props;
 
         super(scope, id);
 
         const instanceRole = this.createNginxReadonlyInstanceRole(props);
         this.asg = new AutoScalingGroup(this, 'OpenSearchMetricsReadonly-MetricsProxyAsg', {
             instanceType: InstanceType.of(InstanceClass.M5, InstanceSize.XLARGE),
-            blockDevices: [{deviceName: '/dev/xvda', volume: BlockDeviceVolume.ebs(50)}], // GB
-            healthCheck: HealthCheck.ec2({grace: Duration.seconds(90)}),
+            blockDevices: [{ deviceName: '/dev/xvda', volume: BlockDeviceVolume.ebs(50) }], // GB
+            healthCheck: HealthCheck.ec2({ grace: Duration.seconds(90) }),
             machineImage: props && props.ami ?
                 MachineImage.fromSsmParameter(props.ami) :
                 MachineImage.latestAmazonLinux2(),

--- a/infrastructure/lib/stacks/route53.ts
+++ b/infrastructure/lib/stacks/route53.ts
@@ -1,7 +1,15 @@
-import {Stack} from "aws-cdk-lib";
-import {Construct} from "constructs";
-import {HostedZone} from "aws-cdk-lib/aws-route53";
-import {Certificate, CertificateValidation} from "aws-cdk-lib/aws-certificatemanager";
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+import { Stack } from "aws-cdk-lib";
+import { Construct } from "constructs";
+import { HostedZone } from "aws-cdk-lib/aws-route53";
+import { Certificate, CertificateValidation } from "aws-cdk-lib/aws-certificatemanager";
 
 export interface Route53Props {
     readonly hostedZone: string,

--- a/infrastructure/lib/stacks/secrets.ts
+++ b/infrastructure/lib/stacks/secrets.ts
@@ -1,6 +1,14 @@
-import {Stack} from "aws-cdk-lib";
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+import { Stack } from "aws-cdk-lib";
+import { Secret } from "aws-cdk-lib/aws-secretsmanager";
 import { Construct } from 'constructs';
-import {Secret} from "aws-cdk-lib/aws-secretsmanager";
 
 export interface SecretProps {
     readonly secretName: string
@@ -9,7 +17,7 @@ export interface SecretProps {
 export class OpenSearchMetricsSecretsStack extends Stack {
     readonly secret: Secret;
 
-    constructor(scope: Construct, id: string, props: SecretProps ) {
+    constructor(scope: Construct, id: string, props: SecretProps) {
         super(scope, id);
         this.secret = new Secret(this, `MetricsCreds-${props.secretName}`, {
             secretName: props.secretName,

--- a/infrastructure/lib/stacks/vpc.ts
+++ b/infrastructure/lib/stacks/vpc.ts
@@ -1,7 +1,15 @@
 
-import {IpAddresses, Peer, Port, SecurityGroup, SelectedSubnets, Subnet, SubnetType, Vpc} from 'aws-cdk-lib/aws-ec2';
-import {CfnOutput, Stack, StackProps} from "aws-cdk-lib";
-import {Construct} from "constructs";
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+import { Stack, StackProps } from "aws-cdk-lib";
+import { Peer, Port, SecurityGroup, SelectedSubnets, SubnetType, Vpc } from 'aws-cdk-lib/aws-ec2';
+import { Construct } from "constructs";
 
 
 export class VpcStack extends Stack {
@@ -17,6 +25,7 @@ export class VpcStack extends Stack {
         });
         this.securityGroup.addIngressRule(Peer.ipv4(this.vpc.vpcCidrBlock), Port.tcp(443), "Allow inbound HTTPS traffic");
         this.subnets = this.vpc.selectSubnets({
-            subnetType: SubnetType.PRIVATE_WITH_EGRESS})
+            subnetType: SubnetType.PRIVATE_WITH_EGRESS
+        })
     }
 }

--- a/infrastructure/lib/stacks/waf.ts
+++ b/infrastructure/lib/stacks/waf.ts
@@ -1,7 +1,14 @@
-import {Stack, StackProps} from "aws-cdk-lib";
-import {Construct} from "constructs";
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+import { Stack, StackProps } from "aws-cdk-lib";
 import { CfnWebACL, CfnWebACLAssociation, CfnWebACLAssociationProps } from 'aws-cdk-lib/aws-wafv2';
-import {ApplicationLoadBalancer, NetworkLoadBalancer} from "aws-cdk-lib/aws-elasticloadbalancingv2";
+import { Construct } from "constructs";
 
 interface WafRule {
     name: string;
@@ -104,7 +111,7 @@ export class WebACLAssociation extends CfnWebACLAssociation {
     }
 }
 
-export interface WafProps extends StackProps{
+export interface WafProps extends StackProps {
     readOnlyLoadBalancerArn: string,
     cognitoLoadBalancerArn: string
     appName: string

--- a/infrastructure/package-lock.json
+++ b/infrastructure/package-lock.json
@@ -22,7 +22,7 @@
         "jest": "^27.5.1",
         "ts-jest": "^27.1.4",
         "ts-node": "^10.7.0",
-        "typescript": "~3.9.7"
+        "typescript": "^4.6.3"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -4407,9 +4407,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "3.9.10",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
-      "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",

--- a/infrastructure/package.json
+++ b/infrastructure/package.json
@@ -17,7 +17,7 @@
     "jest": "^27.5.1",
     "ts-jest": "^27.1.4",
     "ts-node": "^10.7.0",
-    "typescript": "~3.9.7"
+    "typescript": "^4.6.3"
   },
   "dependencies": {
     "aws-cdk-lib": "2.146.0",

--- a/infrastructure/test/hostedzone-stack.test.ts
+++ b/infrastructure/test/hostedzone-stack.test.ts
@@ -1,8 +1,15 @@
-import {App} from "aws-cdk-lib";
-import {VpcStack} from "../lib/stacks/vpc";
-import {Template} from "aws-cdk-lib/assertions";
-import {OpenSearchHealthRoute53} from "../lib/stacks/route53";
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+import { App } from "aws-cdk-lib";
+import { Template } from "aws-cdk-lib/assertions";
 import Project from "../lib/enums/project";
+import { OpenSearchHealthRoute53 } from "../lib/stacks/route53";
 
 test('HostedZone Stack Test', () => {
     const app = new App();

--- a/infrastructure/test/monitoring-stack.test.ts
+++ b/infrastructure/test/monitoring-stack.test.ts
@@ -1,12 +1,20 @@
-import {App} from "aws-cdk-lib";
-import {Template} from "aws-cdk-lib/assertions";
-import {OpenSearchMetricsWorkflowStack} from "../lib/stacks/metricsWorkflow";
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+import { App } from "aws-cdk-lib";
+import { Template } from "aws-cdk-lib/assertions";
+import { OpenSearchMetricsWorkflowStack } from "../lib/stacks/metricsWorkflow";
 import Project from "../lib/enums/project";
-import {OpenSearchDomainStack} from "../lib/stacks/opensearch";
-import {VpcStack} from "../lib/stacks/vpc";
-import {ArnPrincipal} from "aws-cdk-lib/aws-iam";
-import {OpenSearchMetricsMonitoringStack} from "../lib/stacks/monitoringDashboard";
-import {OpenSearchMetricsSecretsStack} from "../lib/stacks/secrets";
+import { OpenSearchDomainStack } from "../lib/stacks/opensearch";
+import { VpcStack } from "../lib/stacks/vpc";
+import { ArnPrincipal } from "aws-cdk-lib/aws-iam";
+import { OpenSearchMetricsMonitoringStack } from "../lib/stacks/monitoringDashboard";
+import { OpenSearchMetricsSecretsStack } from "../lib/stacks/secrets";
 
 test('Monitoring Stack Test', () => {
     const app = new App();

--- a/infrastructure/test/nginx.test.ts
+++ b/infrastructure/test/nginx.test.ts
@@ -1,11 +1,19 @@
-import {App} from "aws-cdk-lib";
-import {VpcStack} from "../lib/stacks/vpc";
-import {Template} from "aws-cdk-lib/assertions";
-import {OpenSearchMetricsNginxReadonly} from "../lib/stacks/opensearchNginxProxyReadonly";
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+import { App } from "aws-cdk-lib";
+import { VpcStack } from "../lib/stacks/vpc";
+import { Template } from "aws-cdk-lib/assertions";
+import { OpenSearchMetricsNginxReadonly } from "../lib/stacks/opensearchNginxProxyReadonly";
 import Project from "../lib/enums/project";
-import {OpenSearchDomainStack} from "../lib/stacks/opensearch";
-import {ArnPrincipal} from "aws-cdk-lib/aws-iam";
-import {OpenSearchHealthRoute53} from "../lib/stacks/route53";
+import { OpenSearchDomainStack } from "../lib/stacks/opensearch";
+import { ArnPrincipal } from "aws-cdk-lib/aws-iam";
+import { OpenSearchHealthRoute53 } from "../lib/stacks/route53";
 
 test('OpenSearchMetricsNginxReadonly Stack Test', () => {
     const app = new App();
@@ -16,7 +24,7 @@ test('OpenSearchMetricsNginxReadonly Stack Test', () => {
         vpcStack: vpcStack,
         enableNginxCognito: true,
         jenkinsAccess: {
-            jenkinsAccountRoles:  [
+            jenkinsAccountRoles: [
                 new ArnPrincipal(Project.JENKINS_MASTER_ROLE),
                 new ArnPrincipal(Project.JENKINS_AGENT_ROLE)
             ]

--- a/infrastructure/test/opensearch-stack.test.ts
+++ b/infrastructure/test/opensearch-stack.test.ts
@@ -1,9 +1,17 @@
-import {App} from "aws-cdk-lib";
-import {Template} from "aws-cdk-lib/assertions";
-import {OpenSearchDomainStack} from "../lib/stacks/opensearch";
-import {ArnPrincipal} from "aws-cdk-lib/aws-iam";
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+import { App } from "aws-cdk-lib";
+import { Template } from "aws-cdk-lib/assertions";
+import { OpenSearchDomainStack } from "../lib/stacks/opensearch";
+import { ArnPrincipal } from "aws-cdk-lib/aws-iam";
 import Project from "../lib/enums/project";
-import {VpcStack} from "../lib/stacks/vpc";
+import { VpcStack } from "../lib/stacks/vpc";
 
 test('OpenSearchDomain Stack Test', () => {
     const app = new App();
@@ -13,7 +21,7 @@ test('OpenSearchDomain Stack Test', () => {
         vpcStack: new VpcStack(app, 'OpenSearchHealth-VPC', {}),
         enableNginxCognito: true,
         jenkinsAccess: {
-            jenkinsAccountRoles:  [
+            jenkinsAccountRoles: [
                 new ArnPrincipal(Project.JENKINS_MASTER_ROLE),
                 new ArnPrincipal(Project.JENKINS_AGENT_ROLE)
             ]

--- a/infrastructure/test/secrets-stack.test.ts
+++ b/infrastructure/test/secrets-stack.test.ts
@@ -1,3 +1,11 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
 import {App} from "aws-cdk-lib";
 import {Template} from "aws-cdk-lib/assertions";
 import {OpenSearchMetricsSecretsStack} from "../lib/stacks/secrets";

--- a/infrastructure/test/vpc-stack.test.ts
+++ b/infrastructure/test/vpc-stack.test.ts
@@ -1,12 +1,16 @@
-// import * as cdk from 'aws-cdk-lib';
-// import { Template } from 'aws-cdk-lib/assertions';
-// import * as Infrastructure from '../lib/infrastructure-stack';
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
 
 // example test. To run these tests, uncomment this file along with the
 // example resource in lib/infrastructure-stack.ts
-import {App} from "aws-cdk-lib";
-import {Template} from "aws-cdk-lib/assertions";
-import {VpcStack} from "../lib/stacks/vpc";
+import { App } from "aws-cdk-lib";
+import { Template } from "aws-cdk-lib/assertions";
+import { VpcStack } from "../lib/stacks/vpc";
 
 test('VPC Stack Test', () => {
     const app = new App();

--- a/infrastructure/test/workflow-stack.test.ts
+++ b/infrastructure/test/workflow-stack.test.ts
@@ -1,10 +1,18 @@
-import {App} from "aws-cdk-lib";
-import {Template} from "aws-cdk-lib/assertions";
-import {OpenSearchMetricsWorkflowStack} from "../lib/stacks/metricsWorkflow";
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+import { App } from "aws-cdk-lib";
+import { Template } from "aws-cdk-lib/assertions";
+import { OpenSearchMetricsWorkflowStack } from "../lib/stacks/metricsWorkflow";
 import Project from "../lib/enums/project";
-import {OpenSearchDomainStack} from "../lib/stacks/opensearch";
-import {VpcStack} from "../lib/stacks/vpc";
-import {ArnPrincipal} from "aws-cdk-lib/aws-iam";
+import { OpenSearchDomainStack } from "../lib/stacks/opensearch";
+import { VpcStack } from "../lib/stacks/vpc";
+import { ArnPrincipal } from "aws-cdk-lib/aws-iam";
 
 test('Workflow Stack Test', () => {
     const app = new App();
@@ -16,7 +24,7 @@ test('Workflow Stack Test', () => {
             vpcStack: vpcStack,
             enableNginxCognito: true,
             jenkinsAccess: {
-                jenkinsAccountRoles:  [
+                jenkinsAccountRoles: [
                     new ArnPrincipal(Project.JENKINS_MASTER_ROLE),
                     new ArnPrincipal(Project.JENKINS_AGENT_ROLE)
                 ]


### PR DESCRIPTION
### Description
* Upgrade typescript to `^4.6.3`
* Adds the missing license to infrastructure code
* Formats the code
* Removes unused and wildcard imports
* Rearranges the imports

IDE used: vscode

### Issues Resolved
part of https://github.com/opensearch-project/opensearch-metrics/issues/55

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
