### PR TITLE
Update release metrics to include the component level release issue and owner details

### DIFF
--- a/src/main/java/org/opensearchmetrics/dagger/MetricsModule.java
+++ b/src/main/java/org/opensearchmetrics/dagger/MetricsModule.java
@@ -6,6 +6,7 @@ import dagger.Provides;
 import org.opensearchmetrics.metrics.general.*;
 import org.opensearchmetrics.metrics.label.LabelMetrics;
 import org.opensearchmetrics.metrics.release.ReleaseBranchChecker;
+import org.opensearchmetrics.metrics.release.ReleaseIssueChecker;
 import org.opensearchmetrics.metrics.release.ReleaseLabelIssuesFetcher;
 import org.opensearchmetrics.metrics.release.ReleaseLabelPullsFetcher;
 import org.opensearchmetrics.metrics.release.ReleaseMetrics;
@@ -143,7 +144,7 @@ public class MetricsModule {
     public ReleaseMetrics getReleaseMetrics(OpenSearchUtil openSearchUtil, ObjectMapper objectMapper,
                                             ReleaseRepoFetcher releaseRepoFetcher, ReleaseLabelIssuesFetcher releaseLabelIssuesFetcher,
                                             ReleaseLabelPullsFetcher releaseLabelPullsFetcher, ReleaseVersionIncrementChecker releaseVersionIncrementChecker,
-                                            ReleaseBranchChecker releaseBranchChecker, ReleaseNotesChecker releaseNotesChecker) {
-        return new ReleaseMetrics(openSearchUtil, objectMapper, releaseRepoFetcher, releaseLabelIssuesFetcher, releaseLabelPullsFetcher, releaseVersionIncrementChecker, releaseBranchChecker, releaseNotesChecker);
+                                            ReleaseBranchChecker releaseBranchChecker, ReleaseNotesChecker releaseNotesChecker, ReleaseIssueChecker releaseIssueChecker) {
+        return new ReleaseMetrics(openSearchUtil, objectMapper, releaseRepoFetcher, releaseLabelIssuesFetcher, releaseLabelPullsFetcher, releaseVersionIncrementChecker, releaseBranchChecker, releaseNotesChecker, releaseIssueChecker);
     }
 }

--- a/src/main/java/org/opensearchmetrics/metrics/release/ReleaseInputs.java
+++ b/src/main/java/org/opensearchmetrics/metrics/release/ReleaseInputs.java
@@ -1,32 +1,33 @@
 package org.opensearchmetrics.metrics.release;
 
 public enum ReleaseInputs {
-    VERSION_3_0_0("3.0.0", "open", "main"),
-    VERSION_2_12_0("2.12.0", "closed", "2.12"),
-    VERSION_2_13_0("2.13.0", "closed", "2.13"),
-    VERSION_2_14_0("2.14.0", "closed", "2.14"),
-    VERSION_2_15_0("2.15.0", "closed", "2.15"),
-    VERSION_2_16_0("2.16.0", "closed", "2.16"),
-    VERSION_2_17_0("2.17.0", "open", "2.x"),
-    VERSION_1_3_15("1.3.15", "closed", "1.3"),
-    VERSION_1_3_16("1.3.16", "closed", "1.3"),
-    VERSION_1_3_17("1.3.17", "closed", "1.3"),
-    VERSION_1_3_18("1.3.18", "closed", "1.3"),
-    VERSION_1_3_19("1.3.19", "open", "1.3");
+    VERSION_3_0_0("3.0.0", "open", "main", true),
+    VERSION_2_12_0("2.12.0", "closed", "2.12", false),
+    VERSION_2_13_0("2.13.0", "closed", "2.13", false),
+    VERSION_2_14_0("2.14.0", "closed", "2.14", false),
+    VERSION_2_15_0("2.15.0", "closed", "2.15", true),
+    VERSION_2_16_0("2.16.0", "closed", "2.16", true),
+    VERSION_2_17_0("2.17.0", "open", "2.x", true),
+    VERSION_1_3_15("1.3.15", "closed", "1.3", false),
+    VERSION_1_3_16("1.3.16", "closed", "1.3", false),
+    VERSION_1_3_17("1.3.17", "closed", "1.3", false),
+    VERSION_1_3_18("1.3.18", "closed", "1.3", true),
+    VERSION_1_3_19("1.3.19", "open", "1.3", true);
 
     private final String version;
     private final String state;
     private final String branch;
 
-    ReleaseInputs(String version, String state, String branch) {
+    private final boolean track;
+
+    ReleaseInputs(String version, String state, String branch, boolean track) {
         this.version = version;
         this.state = state;
         this.branch = branch;
+        this.track = track;
     }
 
-    public String getVersion() {
-        return version;
-    }
+    public String getVersion() { return version; }
 
     public String getState() {
         return state;
@@ -34,6 +35,10 @@ public enum ReleaseInputs {
 
     public String getBranch() {
         return branch;
+    }
+
+    public boolean getTrack() {
+        return track;
     }
     public static ReleaseInputs[] getAllReleaseInputs() {
         return values();

--- a/src/main/java/org/opensearchmetrics/metrics/release/ReleaseIssueChecker.java
+++ b/src/main/java/org/opensearchmetrics/metrics/release/ReleaseIssueChecker.java
@@ -1,0 +1,61 @@
+package org.opensearchmetrics.metrics.release;
+
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.index.query.BoolQueryBuilder;
+import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.search.SearchHit;
+import org.opensearch.search.aggregations.AggregationBuilders;
+import org.opensearch.search.aggregations.bucket.terms.Terms;
+import org.opensearch.search.builder.SearchSourceBuilder;
+import org.opensearchmetrics.util.OpenSearchUtil;
+
+import javax.inject.Inject;
+import java.util.Arrays;
+
+public class ReleaseIssueChecker {
+
+    @Inject
+    public ReleaseIssueChecker() {}
+
+    public String[] releaseOwners(String releaseVersion, String repo, OpenSearchUtil openSearchUtil) {
+        BoolQueryBuilder boolQueryBuilder = QueryBuilders.boolQuery();
+        boolQueryBuilder.must(QueryBuilders.matchQuery("repository.keyword", repo));
+        boolQueryBuilder.must(QueryBuilders.matchQuery("title.keyword", "[RELEASE] Release version " + releaseVersion));
+        boolQueryBuilder.must(QueryBuilders.matchQuery("issue_pull_request", false));
+        SearchRequest searchRequest = new SearchRequest("github_issues");
+        SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
+        searchSourceBuilder.query(boolQueryBuilder);
+        searchSourceBuilder.size(9000);
+        searchSourceBuilder.aggregation(
+                AggregationBuilders.terms("issue_assignees")
+                        .field("issue_assignees.keyword")
+                        .size(50)
+        );
+        searchRequest.source(searchSourceBuilder);
+        SearchResponse searchResponse = openSearchUtil.search(searchRequest);
+        Terms termsAgg = searchResponse.getAggregations().get("issue_assignees");
+        return termsAgg.getBuckets().stream()
+                .map(Terms.Bucket::getKeyAsString)
+                .toArray(String[]::new);
+    }
+
+    public String releaseIssue(String releaseVersion, String repo, OpenSearchUtil openSearchUtil) {
+        BoolQueryBuilder boolQueryBuilder = QueryBuilders.boolQuery();
+        boolQueryBuilder.must(QueryBuilders.matchQuery("repository.keyword", repo));
+        boolQueryBuilder.must(QueryBuilders.matchQuery("title.keyword", "[RELEASE] Release version " + releaseVersion));
+        boolQueryBuilder.must(QueryBuilders.matchQuery("issue_pull_request", false));
+        SearchRequest searchRequest = new SearchRequest("github_issues");
+        SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
+        searchSourceBuilder.query(boolQueryBuilder);
+        searchSourceBuilder.size(9000);
+        searchRequest.source(searchSourceBuilder);
+        SearchResponse searchResponse = openSearchUtil.search(searchRequest);
+        SearchHit[] hits = searchResponse.getHits().getHits();
+        return Arrays.stream(hits)
+                .findFirst()
+                .map(hit -> (String) hit.getSourceAsMap().get("html_url"))
+                .orElse(null);
+    }
+
+}

--- a/src/main/java/org/opensearchmetrics/metrics/release/ReleaseMetrics.java
+++ b/src/main/java/org/opensearchmetrics/metrics/release/ReleaseMetrics.java
@@ -21,12 +21,13 @@ public class ReleaseMetrics {
 
     private final ReleaseNotesChecker releaseNotesChecker;
 
+    private final ReleaseIssueChecker releaseIssueChecker;
 
     @Inject
     public ReleaseMetrics(OpenSearchUtil openSearchUtil, ObjectMapper objectMapper, ReleaseRepoFetcher releaseRepoFetcher,
                           ReleaseLabelIssuesFetcher releaseLabelIssuesFetcher, ReleaseLabelPullsFetcher releaseLabelPullsFetcher,
                           ReleaseVersionIncrementChecker releaseVersionIncrementChecker, ReleaseBranchChecker releaseBranchChecker,
-                          ReleaseNotesChecker releaseNotesChecker) {
+                          ReleaseNotesChecker releaseNotesChecker, ReleaseIssueChecker releaseIssueChecker) {
         this.openSearchUtil = openSearchUtil;
         this.objectMapper = objectMapper;
         this.releaseRepoFetcher = releaseRepoFetcher;
@@ -35,40 +36,39 @@ public class ReleaseMetrics {
         this.releaseVersionIncrementChecker = releaseVersionIncrementChecker;
         this.releaseBranchChecker = releaseBranchChecker;
         this.releaseNotesChecker = releaseNotesChecker;
+        this.releaseIssueChecker = releaseIssueChecker;
     }
-
 
     public List<String> getReleaseRepos(String releaseVersion) {
         return releaseRepoFetcher.getReleaseRepos(releaseVersion);
     }
 
-
     public Long getReleaseLabelIssues(String releaseVersion, String repo, String issueState, boolean autoCut) {
         return releaseLabelIssuesFetcher.releaseLabelIssues(releaseVersion, repo, issueState, autoCut, openSearchUtil);
     }
-
-
 
     public Long getReleaseLabelPulls(String releaseVersion, String repo, String pullState) {
         return releaseLabelPullsFetcher.releaseLabelPulls(releaseVersion, repo, pullState, openSearchUtil);
     }
 
-
-
-
     public boolean getReleaseVersionIncrement (String releaseVersion, String repo, String branch) {
         return releaseVersionIncrementChecker.releaseVersionIncrement(releaseVersion, repo, branch, objectMapper, openSearchUtil);
     }
-
 
     public Boolean getReleaseNotes (String releaseVersion, String repo, String releaseBranch) {
         return releaseNotesChecker.releaseNotes(releaseVersion, repo, releaseBranch);
     }
 
-
-
     public Boolean getReleaseBranch (String releaseVersion, String repo) {
         return releaseBranchChecker.releaseBranch(releaseVersion, repo);
+    }
+
+    public String[] getReleaseOwners (String releaseVersion, String repo) {
+        return releaseIssueChecker.releaseOwners(releaseVersion, repo, openSearchUtil);
+    }
+
+    public String getReleaseIssue (String releaseVersion, String repo) {
+        return releaseIssueChecker.releaseIssue(releaseVersion, repo, openSearchUtil);
     }
 
 

--- a/src/main/java/org/opensearchmetrics/model/release/ReleaseMetricsData.java
+++ b/src/main/java/org/opensearchmetrics/model/release/ReleaseMetricsData.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.Data;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 @Data
@@ -22,6 +23,9 @@ public class ReleaseMetricsData {
 
     @JsonProperty("release_version")
     private String releaseVersion;
+
+    @JsonProperty("version")
+    private String version;
 
     @JsonProperty("release_state")
     private String releaseState;
@@ -49,12 +53,25 @@ public class ReleaseMetricsData {
     @JsonProperty("release_branch")
     private boolean releaseBranch;
 
+    @JsonProperty("release_owners")
+    private String[] releaseOwners;
+
+    @JsonProperty("release_owner_exists")
+    private boolean releaseOwnerExists;
+
+    @JsonProperty("release_issue")
+    private String releaseIssue;
+
+    @JsonProperty("release_issue_exists")
+    private boolean releaseIssueExists;
+
     public String toJson(ObjectMapper mapper) throws JsonProcessingException {
         Map<String, Object> data = new HashMap<>();
         data.put("id", id);
         data.put("current_date", currentDate);
         data.put("repository", repository);
         data.put("release_version", releaseVersion);
+        data.put("version", version);
         data.put("release_state", releaseState);
         data.put("issues_open", issuesOpen);
         data.put("autocut_issues_open", autocutIssuesOpen);
@@ -64,6 +81,10 @@ public class ReleaseMetricsData {
         data.put("version_increment", versionIncrement);
         data.put("release_notes", releaseNotes);
         data.put("release_branch", releaseBranch);
+        data.put("release_owners", releaseOwners);
+        data.put("release_owner_exists", releaseOwnerExists);
+        data.put("release_issue", releaseIssue);
+        data.put("release_issue_exists", releaseIssueExists);
 
         return mapper.writeValueAsString(data);
     }

--- a/src/test/java/org/opensearchmetrics/metrics/release/ReleaseInputsTest.java
+++ b/src/test/java/org/opensearchmetrics/metrics/release/ReleaseInputsTest.java
@@ -56,6 +56,22 @@ public class ReleaseInputsTest {
     }
 
     @Test
+    public void testGetTrack() {
+        assertEquals(true, ReleaseInputs.VERSION_3_0_0.getTrack());
+        assertEquals(false, ReleaseInputs.VERSION_2_12_0.getTrack());
+        assertEquals(false, ReleaseInputs.VERSION_2_13_0.getTrack());
+        assertEquals(false, ReleaseInputs.VERSION_2_14_0.getTrack());
+        assertEquals(true, ReleaseInputs.VERSION_2_15_0.getTrack());
+        assertEquals(true, ReleaseInputs.VERSION_2_16_0.getTrack());
+        assertEquals(true, ReleaseInputs.VERSION_2_17_0.getTrack());
+        assertEquals(false, ReleaseInputs.VERSION_1_3_15.getTrack());
+        assertEquals(false, ReleaseInputs.VERSION_1_3_16.getTrack());
+        assertEquals(false, ReleaseInputs.VERSION_1_3_17.getTrack());
+        assertEquals(true, ReleaseInputs.VERSION_1_3_18.getTrack());
+        assertEquals(true, ReleaseInputs.VERSION_1_3_19.getTrack());
+    }
+
+    @Test
     public void testGetAllReleaseInputs() {
         ReleaseInputs[] releaseInputs = ReleaseInputs.getAllReleaseInputs();
         assertEquals(12, releaseInputs.length);

--- a/src/test/java/org/opensearchmetrics/metrics/release/ReleaseIssueCheckerTest.java
+++ b/src/test/java/org/opensearchmetrics/metrics/release/ReleaseIssueCheckerTest.java
@@ -1,0 +1,79 @@
+package org.opensearchmetrics.metrics.release;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.search.SearchHit;
+import org.opensearch.search.SearchHits;
+import org.opensearch.search.aggregations.Aggregations;
+import org.opensearch.search.aggregations.bucket.terms.Terms;
+import org.opensearchmetrics.util.OpenSearchUtil;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ReleaseIssueCheckerTest {
+
+    @Mock
+    private OpenSearchUtil openSearchUtil;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void testReleaseOwners() {
+        Terms.Bucket bucket1 = mock(Terms.Bucket.class);
+        when(bucket1.getKeyAsString()).thenReturn("sample_user_1");
+        Terms.Bucket bucket2 = mock(Terms.Bucket.class);
+        when(bucket2.getKeyAsString()).thenReturn("sample_user_2");
+        Terms.Bucket bucket3 = mock(Terms.Bucket.class);
+        when(bucket3.getKeyAsString()).thenReturn("sample_user_3");
+        Terms.Bucket bucket4 = mock(Terms.Bucket.class);
+        when(bucket4.getKeyAsString()).thenReturn("sample_user_4");
+        List<Terms.Bucket> buckets = Arrays.asList(bucket1, bucket2, bucket3, bucket4);
+        Terms termsAgg = mock(Terms.class);
+        when(termsAgg.getBuckets()).thenAnswer(invocation -> buckets);
+        Aggregations aggregations = mock(Aggregations.class);
+        when(aggregations.get("issue_assignees")).thenReturn(termsAgg);
+        SearchResponse searchResponse = mock(SearchResponse.class);
+        when(searchResponse.status()).thenReturn(RestStatus.OK);
+        when(searchResponse.getAggregations()).thenReturn(aggregations);
+        OpenSearchUtil openSearchUtil = mock(OpenSearchUtil.class);
+        when(openSearchUtil.search(any(SearchRequest.class))).thenReturn(searchResponse);
+        ReleaseIssueChecker releaseIssueChecker = new ReleaseIssueChecker();
+        String[] result = releaseIssueChecker.releaseOwners("2.16.0", "opensearch-build", openSearchUtil);
+        String[] expected = {"sample_user_1", "sample_user_2", "sample_user_3", "sample_user_4"};
+        assertArrayEquals(expected, result);
+    }
+
+    @Test
+    void testReleaseIssue() {
+        SearchHit hit1 = mock(SearchHit.class);
+        when(hit1.getSourceAsMap()).thenReturn(Map.of("html_url", "https://github.com/opensearch-project/opensearch-build/issues/4115"));
+        SearchHit hit2 = mock(SearchHit.class);
+        when(hit2.getSourceAsMap()).thenReturn(Map.of("html_url", "https://github.com/opensearch-project/opensearch-build/issues/4454"));
+        SearchHits searchHits = mock(SearchHits.class);
+        when(searchHits.getHits()).thenReturn(new SearchHit[]{hit1, hit2});
+        SearchResponse searchResponse = mock(SearchResponse.class);
+        when(searchResponse.getHits()).thenReturn(searchHits);
+        when(searchResponse.status()).thenReturn(RestStatus.OK);
+        OpenSearchUtil openSearchUtil = mock(OpenSearchUtil.class);
+        when(openSearchUtil.search(any(SearchRequest.class))).thenReturn(searchResponse);
+        ReleaseIssueChecker releaseIssueChecker = new ReleaseIssueChecker();
+        String result = releaseIssueChecker.releaseIssue("2.16.0", "opensearch-build", openSearchUtil);
+        assertEquals("https://github.com/opensearch-project/opensearch-build/issues/4115", result);
+    }
+}

--- a/src/test/java/org/opensearchmetrics/metrics/release/ReleaseMetricsTest.java
+++ b/src/test/java/org/opensearchmetrics/metrics/release/ReleaseMetricsTest.java
@@ -41,6 +41,9 @@ public class ReleaseMetricsTest {
     private ReleaseNotesChecker releaseNotesChecker;
 
 
+    @Mock
+    private ReleaseIssueChecker releaseIssueChecker;
+
     @Test
     public void testGetReleaseRepos() {
         MockitoAnnotations.openMocks(this);
@@ -102,5 +105,25 @@ public class ReleaseMetricsTest {
                 .thenReturn(expectedBranch);
         boolean result = releaseBranchChecker.releaseBranch("1.0.0", "testRepo");
         assertEquals(expectedBranch, result);
+    }
+
+    @Test
+    public void testGetReleaseOwner() {
+        MockitoAnnotations.openMocks(this);
+        String[] releaseOwners = new String[]{"sample_user_1"};
+        when(releaseIssueChecker.releaseOwners(anyString(), anyString(), any()))
+                .thenReturn(releaseOwners);
+        String[] result = releaseIssueChecker.releaseOwners("1.0.0", "testRepo", openSearchUtil);
+        assertEquals(releaseOwners, result);
+    }
+
+    @Test
+    public void testGetReleaseIssue() {
+        MockitoAnnotations.openMocks(this);
+        String releaseIssue = "https://sample-release-issue/100";
+        when(releaseIssueChecker.releaseIssue(anyString(), anyString(), any()))
+                .thenReturn(releaseIssue);
+        String result = releaseIssueChecker.releaseIssue("1.0.0", "testRepo", openSearchUtil);
+        assertEquals(releaseIssue, result);
     }
 }

--- a/src/test/java/org/opensearchmetrics/model/release/ReleaseMetricsDataTest.java
+++ b/src/test/java/org/opensearchmetrics/model/release/ReleaseMetricsDataTest.java
@@ -21,6 +21,8 @@ public class ReleaseMetricsDataTest {
 
     private ReleaseMetricsData releaseMetricsData;
 
+    private static String[] SAMPLE_USERS = new String[]{"sample_user"};
+
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
@@ -49,6 +51,12 @@ public class ReleaseMetricsDataTest {
     public void testReleaseVersion() {
         releaseMetricsData.setReleaseVersion("1.0");
         assertEquals("1.0", releaseMetricsData.getReleaseVersion());
+    }
+
+    @Test
+    public void testVersion() {
+        releaseMetricsData.setVersion("1.0");
+        assertEquals("1.0", releaseMetricsData.getVersion());
     }
 
     @Test
@@ -104,6 +112,31 @@ public class ReleaseMetricsDataTest {
         releaseMetricsData.setReleaseBranch(true);
         assertEquals(true, releaseMetricsData.isReleaseBranch());
     }
+
+    @Test
+    public void testReleaseOwners() {
+        releaseMetricsData.setReleaseOwners(SAMPLE_USERS);
+        assertEquals(SAMPLE_USERS, releaseMetricsData.getReleaseOwners());
+    }
+
+    @Test
+    public void testReleaseOwnerExists() {
+        releaseMetricsData.setReleaseOwnerExists(false);
+        assertEquals(false, releaseMetricsData.isReleaseOwnerExists());
+    }
+
+    @Test
+    public void testReleaseIssue() {
+        releaseMetricsData.setReleaseIssue("https://sample-release-issue/100");
+        assertEquals("https://sample-release-issue/100", releaseMetricsData.getReleaseIssue());
+    }
+
+    @Test
+    public void testReleaseIssueExists() {
+        releaseMetricsData.setReleaseIssueExists(false);
+        assertEquals(false, releaseMetricsData.isReleaseIssueExists());
+    }
+
     @Test
     void toJson() throws JsonProcessingException {
         // Arrange
@@ -112,7 +145,12 @@ public class ReleaseMetricsDataTest {
         releaseMetricsData.setCurrentDate("2024-03-15");
         releaseMetricsData.setRepository("test-repo");
         releaseMetricsData.setReleaseVersion("1.0.0");
+        releaseMetricsData.setVersion("1.0.0");
+        releaseMetricsData.setReleaseIssue("https://sample-release-issue/100");
+        releaseMetricsData.setReleaseIssueExists(true);
         releaseMetricsData.setReleaseState("stable");
+        releaseMetricsData.setReleaseOwners(SAMPLE_USERS);
+        releaseMetricsData.setReleaseOwnerExists(true);
         releaseMetricsData.setIssuesOpen(5L);
         releaseMetricsData.setAutocutIssuesOpen(2L);
         releaseMetricsData.setIssuesClosed(3L);
@@ -127,6 +165,7 @@ public class ReleaseMetricsDataTest {
         expectedData.put("current_date", "2024-03-15");
         expectedData.put("repository", "test-repo");
         expectedData.put("release_version", "1.0.0");
+        expectedData.put("version", "1.0.0");
         expectedData.put("release_state", "stable");
         expectedData.put("issues_open", 5L);
         expectedData.put("autocut_issues_open", 2L);
@@ -136,6 +175,10 @@ public class ReleaseMetricsDataTest {
         expectedData.put("version_increment", true);
         expectedData.put("release_notes", true);
         expectedData.put("release_branch", false);
+        expectedData.put("release_owners", SAMPLE_USERS);
+        expectedData.put("release_owner_exists", true);
+        expectedData.put("release_issue","https://sample-release-issue/100");
+        expectedData.put("release_issue_exists", true);
 
         when(objectMapper.writeValueAsString(expectedData)).thenReturn("expectedJson");
 
@@ -154,6 +197,7 @@ public class ReleaseMetricsDataTest {
         releaseMetricsData.setCurrentDate("2024-03-15");
         releaseMetricsData.setRepository("test-repo");
         releaseMetricsData.setReleaseVersion("1.0.0");
+        releaseMetricsData.setVersion("1.0.0");
         releaseMetricsData.setReleaseState("stable");
         releaseMetricsData.setIssuesOpen(5L);
         releaseMetricsData.setAutocutIssuesOpen(2L);
@@ -163,6 +207,10 @@ public class ReleaseMetricsDataTest {
         releaseMetricsData.setVersionIncrement(true);
         releaseMetricsData.setReleaseNotes(true);
         releaseMetricsData.setReleaseBranch(false);
+        releaseMetricsData.setReleaseOwners(SAMPLE_USERS);
+        releaseMetricsData.setReleaseOwnerExists(true);
+        releaseMetricsData.setReleaseIssue("https://sample-release-issue/100");
+        releaseMetricsData.setReleaseIssueExists(true);
 
         when(objectMapper.writeValueAsString(anyMap())).thenReturn("expectedJson");
 
@@ -181,6 +229,7 @@ public class ReleaseMetricsDataTest {
         releaseMetricsData.setCurrentDate("2024-03-15");
         releaseMetricsData.setRepository("test-repo");
         releaseMetricsData.setReleaseVersion("1.0.0");
+        releaseMetricsData.setVersion("1.0.0");
         releaseMetricsData.setReleaseState("stable");
         releaseMetricsData.setIssuesOpen(5L);
         releaseMetricsData.setAutocutIssuesOpen(2L);
@@ -190,6 +239,10 @@ public class ReleaseMetricsDataTest {
         releaseMetricsData.setVersionIncrement(true);
         releaseMetricsData.setReleaseNotes(true);
         releaseMetricsData.setReleaseBranch(false);
+        releaseMetricsData.setReleaseOwners(SAMPLE_USERS);
+        releaseMetricsData.setReleaseOwnerExists(true);
+        releaseMetricsData.setReleaseIssue("https://sample-release-issue/100");
+        releaseMetricsData.setReleaseIssueExists(true);
 
         when(objectMapper.writeValueAsString(anyMap())).thenThrow(JsonProcessingException.class);
 


### PR DESCRIPTION
### Description
Update release metrics to include the component level release issue and owner details.
Sample source document 
```
"_source": {
    "release_notes": true,
    "version_increment": true,
    "release_issue": "https://github.com/opensearch-project/notifications/issues/782",
    "autocut_issues_open": 0,
    "repository": "notifications",
    "release_state": "closed",
    "version": "2.12.0",
    "pulls_open": 0,
    "current_date": "2024-08-20T18:59:43.223873761",
    "release_branch": true,
    "issues_closed": 9,
    "pulls_closed": 10,
    "id": "4bf8c249-9455-3706-9704-fe71adfe5e34",
    "issues_open": 0,
    "release_version": "2.12.0",
    "release_owners": [
      "praveensameneni",
      "sbcd90"
    ]
  },
``` 

<img width="1148" alt="Screenshot 2024-08-20 at 12 18 10 PM" src="https://github.com/user-attachments/assets/1a0756ff-5dca-4c5b-9107-e0d7cf4d2ba7">

### Issues Resolved
Part of https://github.com/opensearch-project/opensearch-metrics/issues/61 and https://github.com/opensearch-project/opensearch-metrics/issues/51

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
