### PR TITLE
Support component name filter for release metrics

### DIFF
--- a/src/main/java/org/opensearchmetrics/metrics/MetricsCalculation.java
+++ b/src/main/java/org/opensearchmetrics/metrics/MetricsCalculation.java
@@ -126,19 +126,19 @@ public class MetricsCalculation {
                                 throw new RuntimeException(e);
                             }
                             return labelInfo.entrySet().stream().flatMap(entry -> {
-                                String labelname = entry.getKey();
+                                String labelName = entry.getKey();
                                 List<Long> values = entry.getValue();
                                 LabelData labelData = new LabelData();
                                 try {
                                     labelData.setId(String.valueOf(UUID.nameUUIDFromBytes(MessageDigest.getInstance("SHA-1")
-                                            .digest(("label-metrics-" + labelname + "-" + currentDate.format(DateTimeFormatter.ofPattern("yyyy-MM-dd")) + "-" + repo)
+                                            .digest(("label-metrics-" + labelName + "-" + currentDate.format(DateTimeFormatter.ofPattern("yyyy-MM-dd")) + "-" + repo)
                                                     .getBytes()))));
                                 } catch (NoSuchAlgorithmException e) {
                                     throw new RuntimeException(e);
                                 }
                                 labelData.setRepository(repo);
                                 labelData.setCurrentDate(currentDate.toString());
-                                labelData.setLabelName(labelname);
+                                labelData.setLabelName(labelName);
                                 labelData.setLabelPullCount(values.get(1));
                                 labelData.setLabelIssueCount(values.get(0));
                                 return Stream.of(labelData);
@@ -155,14 +155,17 @@ public class MetricsCalculation {
         Map<String, String> metricFinalData =
                 Arrays.stream(releaseInputs)
                         .filter(ReleaseInputs::getTrack)
-                        .flatMap(releaseInput -> releaseMetrics.getReleaseRepos(releaseInput.getVersion()).stream()
-                        .flatMap(repo -> {
+                        .flatMap(releaseInput -> releaseMetrics.getReleaseRepos(releaseInput.getVersion()).entrySet().stream()
+                        .flatMap(entry -> {
+                            String repoName = entry.getKey();
+                            String componentName = entry.getValue();
                             ReleaseMetricsData releaseMetricsData = new ReleaseMetricsData();
-                            releaseMetricsData.setRepository(repo);
+                            releaseMetricsData.setRepository(repoName);
+                            releaseMetricsData.setComponent(componentName);
                             releaseMetricsData.setCurrentDate(currentDate.toString());
                             try {
                                 releaseMetricsData.setId(String.valueOf(UUID.nameUUIDFromBytes(MessageDigest.getInstance("SHA-1")
-                                        .digest(("release-metrics-" + releaseInput.getVersion() + "-" + currentDate.format(DateTimeFormatter.ofPattern("yyyy-MM-dd")) + "-" + repo)
+                                        .digest(("release-metrics-" + releaseInput.getVersion() + "-" + currentDate.format(DateTimeFormatter.ofPattern("yyyy-MM-dd")) + "-" + repoName)
                                                 .getBytes()))));
                             } catch (NoSuchAlgorithmException e) {
                                 throw new RuntimeException(e);
@@ -170,20 +173,20 @@ public class MetricsCalculation {
                             releaseMetricsData.setReleaseVersion(releaseInput.getVersion());
                             releaseMetricsData.setVersion(releaseInput.getVersion());
                             releaseMetricsData.setReleaseState(releaseInput.getState());
-                            releaseMetricsData.setIssuesOpen(releaseMetrics.getReleaseLabelIssues(releaseInput.getVersion(), repo, "open", false));
-                            releaseMetricsData.setAutocutIssuesOpen(releaseMetrics.getReleaseLabelIssues(releaseInput.getVersion(), repo, "open", true));
-                            releaseMetricsData.setIssuesClosed(releaseMetrics.getReleaseLabelIssues(releaseInput.getVersion(), repo, "closed", false));
-                            releaseMetricsData.setPullsOpen(releaseMetrics.getReleaseLabelPulls(releaseInput.getVersion(), repo, "open"));
-                            releaseMetricsData.setPullsClosed(releaseMetrics.getReleaseLabelPulls(releaseInput.getVersion(), repo, "closed"));
-                            releaseMetricsData.setVersionIncrement(releaseMetrics.getReleaseVersionIncrement(releaseInput.getVersion(), repo, releaseInput.getBranch()));
-                            releaseMetricsData.setReleaseNotes(releaseMetrics.getReleaseNotes(releaseInput.getVersion(), repo, releaseInput.getBranch()));
-                            releaseMetricsData.setReleaseBranch(releaseMetrics.getReleaseBranch(releaseInput.getVersion(), repo));
-                            String[] releaseOwners = releaseMetrics.getReleaseOwners(releaseInput.getVersion(), repo);
+                            releaseMetricsData.setIssuesOpen(releaseMetrics.getReleaseLabelIssues(releaseInput.getVersion(), repoName, "open", false));
+                            releaseMetricsData.setAutocutIssuesOpen(releaseMetrics.getReleaseLabelIssues(releaseInput.getVersion(), repoName, "open", true));
+                            releaseMetricsData.setIssuesClosed(releaseMetrics.getReleaseLabelIssues(releaseInput.getVersion(), repoName, "closed", false));
+                            releaseMetricsData.setPullsOpen(releaseMetrics.getReleaseLabelPulls(releaseInput.getVersion(), repoName, "open"));
+                            releaseMetricsData.setPullsClosed(releaseMetrics.getReleaseLabelPulls(releaseInput.getVersion(), repoName, "closed"));
+                            releaseMetricsData.setVersionIncrement(releaseMetrics.getReleaseVersionIncrement(releaseInput.getVersion(), repoName, releaseInput.getBranch()));
+                            releaseMetricsData.setReleaseNotes(releaseMetrics.getReleaseNotes(releaseInput.getVersion(), repoName, releaseInput.getBranch()));
+                            releaseMetricsData.setReleaseBranch(releaseMetrics.getReleaseBranch(releaseInput.getVersion(), repoName));
+                            String[] releaseOwners = releaseMetrics.getReleaseOwners(releaseInput.getVersion(), repoName);
                             releaseMetricsData.setReleaseOwners(releaseOwners);
                             releaseMetricsData.setReleaseOwnerExists(Optional.ofNullable(releaseOwners)
                                     .map(owners -> owners.length > 0)
                                     .orElse(false));
-                            String releaseIssue = releaseMetrics.getReleaseIssue(releaseInput.getVersion(), repo);
+                            String releaseIssue = releaseMetrics.getReleaseIssue(releaseInput.getVersion(), repoName);
                             releaseMetricsData.setReleaseIssue(releaseIssue);
                             releaseMetricsData.setReleaseIssueExists(Optional.ofNullable(releaseIssue)
                                     .map(str -> !str.isEmpty())

--- a/src/main/java/org/opensearchmetrics/metrics/release/ReleaseMetrics.java
+++ b/src/main/java/org/opensearchmetrics/metrics/release/ReleaseMetrics.java
@@ -5,6 +5,7 @@ import org.opensearchmetrics.util.OpenSearchUtil;
 
 import javax.inject.Inject;
 import java.util.List;
+import java.util.Map;
 
 public class ReleaseMetrics {
 
@@ -39,9 +40,10 @@ public class ReleaseMetrics {
         this.releaseIssueChecker = releaseIssueChecker;
     }
 
-    public List<String> getReleaseRepos(String releaseVersion) {
+    public Map<String, String> getReleaseRepos(String releaseVersion) {
         return releaseRepoFetcher.getReleaseRepos(releaseVersion);
     }
+
 
     public Long getReleaseLabelIssues(String releaseVersion, String repo, String issueState, boolean autoCut) {
         return releaseLabelIssuesFetcher.releaseLabelIssues(releaseVersion, repo, issueState, autoCut, openSearchUtil);

--- a/src/main/java/org/opensearchmetrics/model/release/ReleaseMetricsData.java
+++ b/src/main/java/org/opensearchmetrics/model/release/ReleaseMetricsData.java
@@ -21,6 +21,9 @@ public class ReleaseMetricsData {
     @JsonProperty("repository")
     private String repository;
 
+    @JsonProperty("component")
+    private String component;
+
     @JsonProperty("release_version")
     private String releaseVersion;
 
@@ -70,6 +73,7 @@ public class ReleaseMetricsData {
         data.put("id", id);
         data.put("current_date", currentDate);
         data.put("repository", repository);
+        data.put("component", component);
         data.put("release_version", releaseVersion);
         data.put("version", version);
         data.put("release_state", releaseState);

--- a/src/test/java/org/opensearchmetrics/metrics/MetricsCalculationTest.java
+++ b/src/test/java/org/opensearchmetrics/metrics/MetricsCalculationTest.java
@@ -1,0 +1,144 @@
+package org.opensearchmetrics.metrics;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatchers;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.index.query.BoolQueryBuilder;
+import org.opensearchmetrics.metrics.general.*;
+import org.opensearchmetrics.metrics.label.LabelMetrics;
+import org.opensearchmetrics.metrics.release.ReleaseInputs;
+import org.opensearchmetrics.metrics.release.ReleaseMetrics;
+import org.opensearchmetrics.model.label.LabelData;
+import org.opensearchmetrics.model.general.MetricsData;
+import org.opensearchmetrics.model.release.ReleaseMetricsData;
+import org.opensearchmetrics.util.OpenSearchUtil;
+
+import java.io.IOException;
+import java.security.NoSuchAlgorithmException;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+public class MetricsCalculationTest {
+    @Mock
+    private OpenSearchUtil openSearchUtil;
+
+    @Mock
+    private ObjectMapper objectMapper;
+
+    @Mock
+    private UntriagedIssues untriagedIssues;
+    @Mock
+    private UncommentedPullRequests uncommentedPullRequests;
+    @Mock
+    private UnlabelledPullRequests unlabelledPullRequests;
+    @Mock
+    private UnlabelledIssues unlabelledIssues;
+    @Mock
+    private MergedPullRequests mergedPullRequests;
+    @Mock
+    private OpenPullRequests openPullRequests;
+    @Mock
+    private OpenIssues openIssues;
+    @Mock
+    private ClosedIssues closedIssues;
+    @Mock
+    private CreatedIssues createdIssues;
+    @Mock
+    private IssueComments issueComments;
+    @Mock
+    private PullComments pullComments;
+    @Mock
+    private IssuePositiveReactions issuePositiveReactions;
+    @Mock
+    private IssueNegativeReactions issueNegativeReactions;
+    @Mock
+    private LabelMetrics labelMetrics;
+    @Mock
+    private ReleaseMetrics releaseMetrics;
+
+    @InjectMocks
+    private MetricsCalculation metricsCalculation;
+
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        metricsCalculation = new MetricsCalculation(openSearchUtil, objectMapper,
+                untriagedIssues, uncommentedPullRequests, unlabelledPullRequests, unlabelledIssues,
+                mergedPullRequests, openPullRequests, openIssues, closedIssues, createdIssues,
+                issueComments, pullComments, issuePositiveReactions, issueNegativeReactions,
+                labelMetrics, releaseMetrics);
+    }
+
+    @Test
+    void testGenerateGeneralMetrics() throws IOException {
+        List<String> repositories = Arrays.asList("repo1", "repo2");
+        MetricsData metricsData = new MetricsData();
+        metricsData.setId("id");
+        metricsData.setRepository("repo1");
+        metricsData.setCurrentDate(LocalDateTime.now(ZoneId.of("UTC")).toString());
+        metricsData.setMetricName("metric");
+        metricsData.setMetricCount(10L);
+        when(untriagedIssues.getBoolQueryBuilder(any())).thenReturn(new BoolQueryBuilder());
+        when(untriagedIssues.createSearchRequest(any(), any())).thenReturn(new SearchRequest());
+        when(untriagedIssues.performSearch(any(), any())).thenReturn(10L);
+        when(objectMapper.writeValueAsString(any())).thenReturn("json");
+        metricsCalculation.generateGeneralMetrics(repositories);
+        verify(openSearchUtil).createIndexIfNotExists("opensearch_general_metrics");
+        verify(openSearchUtil).bulkIndex(eq("opensearch_general_metrics"), any(Map.class));
+    }
+
+    @Test
+    void testGenerateLabelMetrics() throws IOException {
+        List<String> repositories = Arrays.asList("repo1", "repo2");
+        Map<String, List<Long>> labelInfo = new HashMap<>();
+        labelInfo.put("label1", Arrays.asList(5L, 10L));
+        LabelData labelData = new LabelData();
+        labelData.setId("id");
+        labelData.setRepository("repo1");
+        labelData.setCurrentDate(LocalDateTime.now(ZoneId.of("UTC")).toString());
+        labelData.setLabelName("label1");
+        labelData.setLabelPullCount(10L);
+        labelData.setLabelIssueCount(5L);
+        when(labelMetrics.getLabelInfo(any(), any())).thenReturn(labelInfo);
+        when(objectMapper.writeValueAsString(any())).thenReturn("json");
+        metricsCalculation.generateLabelMetrics(repositories);
+        verify(openSearchUtil).createIndexIfNotExists("opensearch_label_metrics");
+        verify(openSearchUtil).bulkIndex(eq("opensearch_label_metrics"), any(Map.class));
+    }
+
+    @Test
+    void testGenerateReleaseMetrics() {
+        Map<String, String> releaseRepos = new HashMap<>();
+        releaseRepos.put("repo1", "component1");
+        releaseRepos.put("repo2", "component2");
+        when(releaseMetrics.getReleaseRepos("2.13.0")).thenReturn(releaseRepos);
+        when(releaseMetrics.getReleaseLabelIssues(ReleaseInputs.VERSION_2_13_0.getVersion(), "repo1", "open", false)).thenReturn(10L);
+        when(releaseMetrics.getReleaseLabelIssues(ReleaseInputs.VERSION_2_13_0.getVersion(), "repo1", "open", true)).thenReturn(5L);
+        when(releaseMetrics.getReleaseLabelIssues(ReleaseInputs.VERSION_2_13_0.getVersion(), "repo1", "closed", false)).thenReturn(20L);
+        when(releaseMetrics.getReleaseLabelPulls(ReleaseInputs.VERSION_2_13_0.getVersion(), "repo1", "open")).thenReturn(3L);
+        when(releaseMetrics.getReleaseLabelPulls(ReleaseInputs.VERSION_2_13_0.getVersion(), "repo1", "closed")).thenReturn(8L);
+        when(releaseMetrics.getReleaseVersionIncrement(ReleaseInputs.VERSION_2_13_0.getVersion(), "repo1", "main")).thenReturn(true);
+        when(releaseMetrics.getReleaseNotes(ReleaseInputs.VERSION_2_13_0.getVersion(), "repo1", "main")).thenReturn(true);
+        when(releaseMetrics.getReleaseBranch(ReleaseInputs.VERSION_2_13_0.getVersion(), "repo1")).thenReturn(true);
+        when(releaseMetrics.getReleaseOwners(ReleaseInputs.VERSION_2_13_0.getVersion(), "repo1")).thenReturn(new String[]{"owner1", "owner2"});
+        when(releaseMetrics.getReleaseIssue(ReleaseInputs.VERSION_2_13_0.getVersion(), "repo1")).thenReturn("release-123");
+        metricsCalculation.generateReleaseMetrics();
+        verify(openSearchUtil).createIndexIfNotExists("opensearch_release_metrics");
+        verify(openSearchUtil).bulkIndex(eq("opensearch_release_metrics"), ArgumentMatchers.anyMap());
+        verify(openSearchUtil, times(1)).createIndexIfNotExists("opensearch_release_metrics");
+    }
+}

--- a/src/test/java/org/opensearchmetrics/metrics/release/ReleaseMetricsTest.java
+++ b/src/test/java/org/opensearchmetrics/metrics/release/ReleaseMetricsTest.java
@@ -8,6 +8,7 @@ import org.opensearchmetrics.util.OpenSearchUtil;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -47,10 +48,10 @@ public class ReleaseMetricsTest {
     @Test
     public void testGetReleaseRepos() {
         MockitoAnnotations.openMocks(this);
-        List<String> repos = Collections.singletonList("testRepo");
+        Map<String, String> repos = Collections.singletonMap("testRepo", "testComponent");
         when(releaseRepoFetcher.getReleaseRepos(anyString())).thenReturn(repos);
-        List<String> result = releaseRepoFetcher.getReleaseRepos("1.0.0");
-        assertSame(repos, result);
+        Map<String, String> result = releaseRepoFetcher.getReleaseRepos("1.0.0");
+        assertEquals(repos, result);
     }
 
     @Test

--- a/src/test/java/org/opensearchmetrics/model/release/ReleaseMetricsDataTest.java
+++ b/src/test/java/org/opensearchmetrics/model/release/ReleaseMetricsDataTest.java
@@ -48,6 +48,12 @@ public class ReleaseMetricsDataTest {
     }
 
     @Test
+    public void testCOmponent() {
+        releaseMetricsData.setComponent("exampleComponent");
+        assertEquals("exampleComponent", releaseMetricsData.getComponent());
+    }
+
+    @Test
     public void testReleaseVersion() {
         releaseMetricsData.setReleaseVersion("1.0");
         assertEquals("1.0", releaseMetricsData.getReleaseVersion());
@@ -144,6 +150,7 @@ public class ReleaseMetricsDataTest {
         releaseMetricsData.setId("1");
         releaseMetricsData.setCurrentDate("2024-03-15");
         releaseMetricsData.setRepository("test-repo");
+        releaseMetricsData.setComponent("test-component");
         releaseMetricsData.setReleaseVersion("1.0.0");
         releaseMetricsData.setVersion("1.0.0");
         releaseMetricsData.setReleaseIssue("https://sample-release-issue/100");
@@ -164,6 +171,7 @@ public class ReleaseMetricsDataTest {
         expectedData.put("id", "1");
         expectedData.put("current_date", "2024-03-15");
         expectedData.put("repository", "test-repo");
+        expectedData.put("component", "test-component");
         expectedData.put("release_version", "1.0.0");
         expectedData.put("version", "1.0.0");
         expectedData.put("release_state", "stable");
@@ -196,6 +204,7 @@ public class ReleaseMetricsDataTest {
         releaseMetricsData.setId("1");
         releaseMetricsData.setCurrentDate("2024-03-15");
         releaseMetricsData.setRepository("test-repo");
+        releaseMetricsData.setComponent("test-component");
         releaseMetricsData.setReleaseVersion("1.0.0");
         releaseMetricsData.setVersion("1.0.0");
         releaseMetricsData.setReleaseState("stable");
@@ -228,6 +237,7 @@ public class ReleaseMetricsDataTest {
         releaseMetricsData.setId("1");
         releaseMetricsData.setCurrentDate("2024-03-15");
         releaseMetricsData.setRepository("test-repo");
+        releaseMetricsData.setComponent("test-component");
         releaseMetricsData.setReleaseVersion("1.0.0");
         releaseMetricsData.setVersion("1.0.0");
         releaseMetricsData.setReleaseState("stable");


### PR DESCRIPTION
### Description
Support component name for release metrics. This should be able to help user filter the documents with repo name or component name. In the following example find the result either by `anomaly-detection-dashboards-plugin` or by `anomalyDetectionDashboards` should yield the same results.

```
 "_source": {
    "release_issue_exists": true,
    "release_notes": false,
    "version_increment": true,
    "release_issue": "https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/issues/802",
    "autocut_issues_open": 0,
    "repository": "anomaly-detection-dashboards-plugin",
    "release_state": "closed",
    "version": "2.15.0",
    "pulls_open": 0,
    "release_owner_exists": false,
    "current_date": "2024-08-26T21:25:20.901042281",
    "component": "anomalyDetectionDashboards",
    "release_branch": true,
    "issues_closed": 5,
    "pulls_closed": 5,
    "id": "1c8b312c-dd16-3443-988e-d3525b2b7715",
    "issues_open": 0,
    "release_version": "2.15.0",
    "release_owners": []
  },
```

### Issues Resolved
Part of https://github.com/opensearch-project/opensearch-metrics/issues/51 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
