### PR TITLE
Support central of the metrics

### DIFF
--- a/infrastructure/lib/stacks/opensearchNginxProxyReadonly.ts
+++ b/infrastructure/lib/stacks/opensearchNginxProxyReadonly.ts
@@ -176,6 +176,7 @@ export class OpenSearchMetricsNginxReadonly extends Stack {
                 add_header Strict-Transport-Security "max-age=47304000; includeSubDomains";
                 add_header X-Content-Type-Options "nosniff";
                 add_header X-Frame-Options "DENY";  
+                add_header Content-Security-Policy "frame-ancestors https://opensearch.org";
                 add_header Cache-Control "no-store, no-cache";
                 
                 set $os_endpoint ${nginxProps.opensearchDashboardUrlProps.opensearchDashboardVpcUrl};


### PR DESCRIPTION
### Description
Support central of the metrics in the https://opensearch.org/. The solution is based on this comment https://github.com/opensearch-project/opensearch-metrics/issues/69#issuecomment-2322060961.

This PR should allow the Iframe embedding on for https://opensearch.org and DENY by default.

### Issues Resolved
Part of https://github.com/opensearch-project/opensearch-metrics/issues/69 and https://github.com/opensearch-project/opensearch-metrics/issues/51

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
