### PR TITLE
Resources to launch GitHub Automation App

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -22,6 +22,7 @@ So you want to contribute code to this project? Excellent! We're glad you're her
     - `cdk deploy OpenSearchMetricsNginxReadonly`: To deploy the dashboard read only setup.
     - `cdk deploy OpenSearchWAF`: To deploy the AWS WAF for the project ALB's.
     - `cdk deploy OpenSearchMetrics-Monitoring`: To deploy the alerting stack which will monitor the step functions and URL of the project coming from [METRICS_HOSTED_ZONE](https://github.com/opensearch-project/opensearch-metrics/blob/main/infrastructure/lib/enums/project.ts)
+    - `cdk deploy OpenSearchMetrics-GitHubAutomationApp`: Create the resources which launches the [GitHub Automation App](https://github.com/opensearch-project/automation-app). Listens to GitHub events and index the data to Metrics cluster.
 
 ### Forking and Cloning
 

--- a/infrastructure/lib/stacks/gitHubAutomationApp.ts
+++ b/infrastructure/lib/stacks/gitHubAutomationApp.ts
@@ -1,0 +1,137 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+import { Aspects, Duration, Stack, Tag, Tags } from 'aws-cdk-lib';
+import {
+    AutoScalingGroup,
+    BlockDeviceVolume,
+    CfnLaunchConfiguration,
+    HealthCheck,
+    UpdatePolicy
+} from 'aws-cdk-lib/aws-autoscaling';
+import {
+    InstanceClass,
+    InstanceSize,
+    InstanceType,
+    MachineImage,
+    SubnetType,
+    Vpc
+} from 'aws-cdk-lib/aws-ec2';
+import {
+    ArnPrincipal,
+    CompositePrincipal,
+    Effect,
+    ManagedPolicy,
+    PolicyStatement,
+    Role,
+    ServicePrincipal
+} from 'aws-cdk-lib/aws-iam';
+import { Construct } from 'constructs';
+import { Secret } from "aws-cdk-lib/aws-secretsmanager";
+
+
+export interface GitHubAppProps {
+    readonly vpc: Vpc;
+    readonly region: string;
+    readonly account: string;
+    readonly ami?: string
+    readonly secret: Secret;
+}
+
+
+export class GitHubAutomationApp extends Stack {
+
+    readonly asg: AutoScalingGroup;
+    readonly githubAppRole: Role;
+
+    constructor(scope: Construct, id: string, props: GitHubAppProps) {
+        super(scope, id);
+
+        const instanceRole = this.createInstanceRole(props.secret.secretArn, props.account);
+        this.githubAppRole = instanceRole;
+
+        this.asg = new AutoScalingGroup(this, 'OpenSearchMetrics-GitHubAutomationApp-Asg', {
+            instanceType: InstanceType.of(InstanceClass.M5, InstanceSize.LARGE),
+            blockDevices: [{deviceName: '/dev/xvda', volume: BlockDeviceVolume.ebs(20)}],
+            healthCheck: HealthCheck.ec2({grace: Duration.seconds(90)}),
+            machineImage: props && props.ami ?
+                MachineImage.fromSsmParameter(props.ami) :
+                MachineImage.latestAmazonLinux2(),
+            associatePublicIpAddress: false,
+            allowAllOutbound: true,
+            desiredCapacity: 1,
+            minCapacity: 1,
+            vpc: props.vpc,
+            vpcSubnets: {
+                subnetType: SubnetType.PRIVATE_WITH_EGRESS
+            },
+            role: instanceRole,
+            updatePolicy: UpdatePolicy.replacingUpdate()
+        });
+        Tags.of(this.asg).add("Name", "OpenSearchMetrics-GitHubAutomationApp")
+
+
+        const launchConfiguration = this.asg.node.findChild('LaunchConfig') as CfnLaunchConfiguration;
+        launchConfiguration.metadataOptions = {
+            httpPutResponseHopLimit: 2,
+            httpEndpoint: "enabled",
+            httpTokens: "required"
+        };
+
+        const instanceName = 'OpenSearchMetrics-GitHubAutomationApp-Host';
+        Aspects.of(this.asg).add(new Tag('name', instanceName, {
+            applyToLaunchedInstances: true,
+            includeResourceTypes: ['AWS::AutoScaling::AutoScalingGroup']
+        }),);
+        this.asg.addUserData(...this.getUserData(props.secret.secretName));
+    }
+
+    private createInstanceRole(secretArn: string, account: string): Role {
+        const role = new Role(this, "OpenSearchMetrics-GitHubAutomationApp-Role", {
+            assumedBy: new CompositePrincipal(
+                new ServicePrincipal('ec2.amazonaws.com'),
+                new ArnPrincipal(`arn:aws:iam::${account}:role/OpenSearchMetrics-GitHubAutomationApp-Role`)
+            ),
+            roleName: "OpenSearchMetrics-GitHubAutomationApp-Role",
+        });
+        role.addManagedPolicy(ManagedPolicy.fromAwsManagedPolicyName('AmazonSSMManagedInstanceCore'));
+        role.addToPolicy(
+            new PolicyStatement({
+                effect: Effect.ALLOW,
+                actions: ["secretsmanager:GetSecretValue"],
+                resources: [secretArn],
+            }),
+        );
+        role.addToPolicy(
+            new PolicyStatement({
+                effect: Effect.ALLOW,
+                actions: ["sts:AssumeRole"],
+                resources: [role.roleArn],
+            }),
+        );
+        return role;
+    }
+
+
+    private getUserData(secretName: string): string[] {
+        return [
+            'sudo yum install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm',
+            'sudo dnf update -y',
+            'sudo yum install git docker -y',
+            'sudo systemctl enable docker',
+            'sudo systemctl start docker',
+            'sudo curl -L https://github.com/docker/compose/releases/latest/download/docker-compose-$(uname -s)-$(uname -m) -o /usr/local/sbin/docker-compose',
+            'sudo chmod a+x /usr/local/sbin/docker-compose',
+            'git clone https://github.com/opensearch-project/automation-app.git',
+            `aws secretsmanager get-secret-value --secret-id ${secretName} --query SecretString --output text >> automation-app/.env`,
+            'cd automation-app/docker',
+            'PORT=8080 RESOURCE_CONFIG=configs/resources/opensearch-project-resource.yml OPERATION_CONFIG=configs/operations/github-merged-pulls-monitor.yml docker-compose -p github-merged-pulls-monitor up -d',
+            'PORT=8081 RESOURCE_CONFIG=configs/resources/opensearch-project-resource.yml OPERATION_CONFIG=configs/operations/github-workflow-runs-monitor.yml docker-compose -p github-workflow-runs-monitor up -d'
+        ];
+    }
+}

--- a/infrastructure/test/gitHubAutomationApp-stack.test.ts
+++ b/infrastructure/test/gitHubAutomationApp-stack.test.ts
@@ -1,0 +1,68 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+import { App } from "aws-cdk-lib";
+import { Match, Template } from "aws-cdk-lib/assertions";
+import Project from "../lib/enums/project";
+import { VpcStack } from "../lib/stacks/vpc";
+import { GitHubAutomationApp } from "../lib/stacks/gitHubAutomationApp";
+import { OpenSearchMetricsSecretsStack } from "../lib/stacks/secrets";
+
+
+test('OpenSearch GitHub App Stack test ', () => {
+    const app = new App();
+    const vpcStack = new VpcStack(app, "Test-OpenSearchHealth-VPC", {});
+    const openSearchMetricsGitHubAppSecretStack = new OpenSearchMetricsSecretsStack(app, "Test-OpenSearchMetrics-GitHubAutomationApp-Secret", {
+        secretName: 'test-github-app-creds'
+    });
+    const gitHubApp = new GitHubAutomationApp(app, "Test-OpenSearchMetrics-GitHubAutomationApp", {
+        vpc: vpcStack.vpc,
+        region: Project.REGION,
+        account: Project.AWS_ACCOUNT,
+        ami: Project.EC2_AMI_SSM.toString(),
+        secret: openSearchMetricsGitHubAppSecretStack.secret
+    });
+
+    const template = Template.fromStack(gitHubApp);
+    template.resourceCountIs('AWS::IAM::Role', 1);
+    template.hasResourceProperties('AWS::IAM::Role', {
+        AssumeRolePolicyDocument: {
+            Statement: Match.arrayWith([
+                {
+                    Action: "sts:AssumeRole",
+                    Effect: "Allow",
+                    Principal: {
+                        Service: "ec2.amazonaws.com"
+                    }
+                }
+            ])
+        }
+    });
+    template.hasResourceProperties('AWS::EC2::SecurityGroup', {
+        GroupDescription: Match.stringLikeRegexp('Test-OpenSearchMetrics-GitHubAutomationApp/OpenSearchMetrics-GitHubAutomationApp-Asg/InstanceSecurityGroup')
+    });
+    template.resourceCountIs('AWS::IAM::Policy', 1);
+    template.hasResourceProperties('AWS::IAM::Policy', {
+        PolicyDocument: {
+            Statement: Match.arrayWith([
+                Match.objectLike({
+                    Action: "secretsmanager:GetSecretValue",
+                    Effect: "Allow",
+                    Resource: {
+                        "Fn::ImportValue": Match.stringLikeRegexp('Test-OpenSearchMetrics-GitHubAutomationApp-Secret:ExportsOutputRefMetricsCreds.*')
+                    }
+                })
+            ])
+        }
+    });
+    template.hasResourceProperties('AWS::AutoScaling::AutoScalingGroup', {
+        DesiredCapacity: "1",
+        MaxSize: "1",
+        MinSize: "1",
+    })
+});


### PR DESCRIPTION
### Description
Resources to launch GitHub Automation App

- This PR needs to be merged https://github.com/opensearch-project/automation-app/pull/12 1st.
- After the above PR is merged, the new CDK stacks will create a GitHub app secret (update the secret value) and resources to launch the GitHub app.
      - Ec2 autoscaling group with right launch configuration to run the app.
      - Permissions to the Ec2 role to fetch the GitHub app secret and list to the GitHub events.
      - Runs 2 docker containers to support [github-merged-pulls-monitor](https://github.com/opensearch-project/automation-app/blob/main/src/call/github-merged-pulls-monitor.ts) and [github-workflow-runs-monitor](https://github.com/opensearch-project/automation-app/blob/main/src/call/github-workflow-runs-monitor.ts).
      - Permissions to index the data to metrics cluster using sigv4.

### Issues Resolved
Part of https://github.com/opensearch-project/opensearch-build/issues/4941 and https://github.com/opensearch-project/automation-app/issues/9

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
