### PR TITLE
Github Automation App to monitor the critical workflows

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -22,6 +22,8 @@ So you want to contribute code to this project? Excellent! We're glad you're her
     - `cdk deploy OpenSearchMetricsNginxReadonly`: To deploy the dashboard read only setup.
     - `cdk deploy OpenSearchWAF`: To deploy the AWS WAF for the project ALB's.
     - `cdk deploy OpenSearchMetrics-Monitoring`: To deploy the alerting stack which will monitor the step functions and URL of the project coming from [METRICS_HOSTED_ZONE](https://github.com/opensearch-project/opensearch-metrics/blob/main/infrastructure/lib/enums/project.ts)
+    - `cdk deploy OpenSearchMetrics-GitHubAutomationApp-Secret`: Creates the GitHub app secret which will be used during the GitHub app runtime.
+    - `cdk deploy OpenSearchMetrics-GitHubWorkflowMonitor-Alarms`: Creates the Alarms to Monitor the Critical GitHub CI workflows by the GitHub Automation App.
     - `cdk deploy OpenSearchMetrics-GitHubAutomationApp`: Create the resources which launches the [GitHub Automation App](https://github.com/opensearch-project/automation-app). Listens to GitHub events and index the data to Metrics cluster.
 
 ### Forking and Cloning

--- a/infrastructure/lib/stacks/gitHubWorkflowMonitorAlarms.ts
+++ b/infrastructure/lib/stacks/gitHubWorkflowMonitorAlarms.ts
@@ -1,0 +1,48 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+import {Duration, Stack} from "aws-cdk-lib";
+import {Construct} from "constructs";
+import {Alarm, ComparisonOperator, Metric, TreatMissingData} from "aws-cdk-lib/aws-cloudwatch";
+
+export interface AlarmProps {
+    readonly namespace: string;
+    readonly metricName: string;
+    readonly workflows: string[];
+}
+
+export class GitHubWorkflowMonitorAlarms extends Stack {
+    readonly workflowAlarmsArn: string[] = [];
+    readonly metricName: string
+    constructor(scope: Construct, id: string, props: AlarmProps) {
+        super(scope, id);
+        props.workflows.forEach(workflow => {
+            const dimensionValue = workflow;
+            const workflowMetric = new Metric({
+                namespace: props.namespace,
+                metricName: props.metricName,
+                dimensionsMap: {
+                    Workflow: dimensionValue,
+                },
+                period: Duration.minutes(5),
+                statistic: 'Sum',
+            });
+
+            const alarm = new Alarm (this, `OpenSearchMetrics-GitHubApp-${dimensionValue.replace(/\s+/g, '')}-FailuresAlarm`, {
+                alarmName: `OpenSearchMetrics-GitHubApp-${dimensionValue.replace(/\s+/g, '')}-FailuresAlarm`,
+                metric: workflowMetric,
+                threshold: 2,
+                evaluationPeriods: 1,
+                comparisonOperator: ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+                alarmDescription: `Alarm for ${workflow} failures`,
+                actionsEnabled: true,
+            });
+            this.workflowAlarmsArn.push(alarm.alarmArn)
+        });
+    }
+}

--- a/infrastructure/test/githubWorkflowMonitorAlarms-stack.test.ts
+++ b/infrastructure/test/githubWorkflowMonitorAlarms-stack.test.ts
@@ -1,0 +1,59 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+import {App} from "aws-cdk-lib";
+import {GitHubWorkflowMonitorAlarms} from "../lib/stacks/gitHubWorkflowMonitorAlarms";
+import {Match, Template} from "aws-cdk-lib/assertions";
+
+test('OpenSearch Workflow Monitor Alarms test ', () => {
+    const app = new App();
+
+    const gitHubWorkflowMonitorAlarms = new GitHubWorkflowMonitorAlarms(app, "Test-OpenSearchMetrics-GitHubWorkflowMonitor-Alarms", {
+        namespace: 'GitHubActions',
+        metricName: 'WorkflowRunFailures',
+        workflows: [
+            'Publish snapshots to Apache Maven repositories',
+            'Publish snapshots to maven',
+            'Run performance benchmark on pull request',
+        ],
+    });
+
+    const template = Template.fromStack(gitHubWorkflowMonitorAlarms);
+    
+
+    template.hasResourceProperties('AWS::CloudWatch::Alarm', {
+        AlarmName: 'OpenSearchMetrics-GitHubApp-Publishsnapshotstomaven-FailuresAlarm',
+        Namespace: 'GitHubActions',
+        MetricName: 'WorkflowRunFailures',
+        Dimensions: Match.arrayWith([{
+            Name: 'Workflow',
+            Value: 'Publish snapshots to maven'
+        }]),
+        ComparisonOperator: 'GreaterThanOrEqualToThreshold',
+        EvaluationPeriods: 1,
+        Threshold: 2,
+        Period: 300,
+        Statistic: 'Sum'
+    });
+
+    template.hasResourceProperties('AWS::CloudWatch::Alarm', {
+        AlarmName: 'OpenSearchMetrics-GitHubApp-Runperformancebenchmarkonpullrequest-FailuresAlarm',
+        Namespace: 'GitHubActions',
+        MetricName: 'WorkflowRunFailures',
+        Dimensions: Match.arrayWith([{
+            Name: 'Workflow',
+            Value: 'Run performance benchmark on pull request'
+        }]),
+        ComparisonOperator: 'GreaterThanOrEqualToThreshold',
+        EvaluationPeriods: 1,
+        Threshold: 2,
+        Period: 300,
+        Statistic: 'Sum'
+    });
+
+});


### PR DESCRIPTION
### Description
Github Automation App to monitor the critical workflows:

- Creates the Alarms for each critical workflow.
- Creates the Alarms for each critical workflow with restrictive metric and namespace.
    - The app logic during runtime and based on the workflow result will update the workflow specific alarm metrics, related PR https://github.com/opensearch-project/automation-app/pull/21.
- The GitHub App role will have restrictive access to publish the alarm metrics.

### Issues Resolved
Part of https://github.com/opensearch-project/opensearch-build/issues/4941

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
