### PR TITLE
Added functionality to store github events in s3 bucket

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -25,6 +25,7 @@ So you want to contribute code to this project? Excellent! We're glad you're her
     - `cdk deploy OpenSearchMetrics-GitHubAutomationApp-Secret`: Creates the GitHub app secret which will be used during the GitHub app runtime.
     - `cdk deploy OpenSearchMetrics-GitHubWorkflowMonitor-Alarms`: Creates the Alarms to Monitor the Critical GitHub CI workflows by the GitHub Automation App.
     - `cdk deploy OpenSearchMetrics-GitHubAutomationApp`: Create the resources which launches the [GitHub Automation App](https://github.com/opensearch-project/automation-app). Listens to GitHub events and index the data to Metrics cluster.
+    - `cdk deploy OpenSearchMetrics-GitHubAutomationAppEvents-S3`: Creates the S3 Bucket for the [GitHub Automation App](https://github.com/opensearch-project/automation-app) to store OpenSearch Project GitHub Events.
 
 ### Forking and Cloning
 

--- a/infrastructure/lib/infrastructure-stack.ts
+++ b/infrastructure/lib/infrastructure-stack.ts
@@ -20,6 +20,7 @@ import { OpenSearchMetricsNginxCognito } from "./constructs/opensearchNginxProxy
 import { OpenSearchMetricsMonitoringStack } from "./stacks/monitoringDashboard";
 import { OpenSearchMetricsSecretsStack } from "./stacks/secrets";
 import { GitHubAutomationApp } from "./stacks/gitHubAutomationApp";
+import { OpenSearchS3 } from "./stacks/s3";
 import { GitHubWorkflowMonitorAlarms } from "./stacks/gitHubWorkflowMonitorAlarms";
 
 export class InfrastructureStack extends Stack {
@@ -47,6 +48,9 @@ export class InfrastructureStack extends Stack {
       ],
     });
 
+    // Create S3 bucket for the GitHub Events
+    const openSearchEventsS3Bucket = new OpenSearchS3(app, "OpenSearchMetrics-GitHubAutomationAppEvents-S3");
+
     // Create resources to launch the GitHub Automation App
     const gitHubAutomationApp = new GitHubAutomationApp(app, "OpenSearchMetrics-GitHubAutomationApp", {
       vpc: vpcStack.vpc,
@@ -54,8 +58,9 @@ export class InfrastructureStack extends Stack {
       account: Project.AWS_ACCOUNT,
       ami: Project.EC2_AMI_SSM.toString(),
       secret: openSearchMetricsGitHubAutomationAppSecretStack.secret,
-      workflowAlarmsArn: gitHubWorkflowMonitorAlarms.workflowAlarmsArn
-    })
+      workflowAlarmsArn: gitHubWorkflowMonitorAlarms.workflowAlarmsArn,
+      githubEventsBucketArn: openSearchEventsS3Bucket.bucket.bucketArn
+    });
 
 
     // Create OpenSearch Domain, roles, permissions, cognito setup, cross account OpenSearch access for jenkins

--- a/infrastructure/lib/stacks/s3.ts
+++ b/infrastructure/lib/stacks/s3.ts
@@ -1,0 +1,29 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+import {Stack, RemovalPolicy, StackProps} from "aws-cdk-lib";
+import { Bucket, BlockPublicAccess, BucketEncryption } from 'aws-cdk-lib/aws-s3';
+import { Construct } from "constructs";
+
+export class OpenSearchS3 extends Stack {
+
+    public readonly bucket: Bucket;
+
+    constructor(scope: Construct, id: string, props?: StackProps) {
+        super(scope, id);
+
+        this.bucket = new Bucket(this, 'OpenSearchS3Bucket', {
+            publicReadAccess: false,
+            blockPublicAccess: BlockPublicAccess.BLOCK_ALL,
+            encryption: BucketEncryption.S3_MANAGED,
+            enforceSSL: true,
+            versioned: true,
+            removalPolicy: RemovalPolicy.RETAIN,
+        });
+    }
+}

--- a/infrastructure/lib/stacks/vpc.ts
+++ b/infrastructure/lib/stacks/vpc.ts
@@ -11,7 +11,6 @@ import { Stack, StackProps } from "aws-cdk-lib";
 import { Peer, Port, SecurityGroup, SelectedSubnets, SubnetType, Vpc } from 'aws-cdk-lib/aws-ec2';
 import { Construct } from "constructs";
 
-
 export class VpcStack extends Stack {
     public readonly vpc: Vpc;
     public readonly securityGroup: SecurityGroup

--- a/infrastructure/test/s3-stack.test.ts
+++ b/infrastructure/test/s3-stack.test.ts
@@ -1,0 +1,84 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+import { App } from "aws-cdk-lib";
+import { Template } from "aws-cdk-lib/assertions";
+import {OpenSearchS3} from "../lib/stacks/s3";
+
+test('S3 Stack Test', () => {
+    const app = new App();
+    const s3Stack = new OpenSearchS3(app, "Test-OpenSearchMetrics-GitHubAutomationAppEvents-S3");
+    const s3StackTemplate = Template.fromStack(s3Stack);
+    s3StackTemplate.resourceCountIs('AWS::S3::Bucket', 1);
+    s3StackTemplate.resourceCountIs('AWS::S3::BucketPolicy', 1);
+    s3StackTemplate.hasResourceProperties('AWS::S3::Bucket', {
+        "BucketEncryption": {
+            "ServerSideEncryptionConfiguration": [
+                {
+                    "ServerSideEncryptionByDefault": {
+                        "SSEAlgorithm": "AES256"
+                    }
+                }
+            ]
+        },
+        "PublicAccessBlockConfiguration": {
+            "BlockPublicAcls": true,
+            "BlockPublicPolicy": true,
+            "IgnorePublicAcls": true,
+            "RestrictPublicBuckets": true
+        },
+        "VersioningConfiguration": {
+            "Status": "Enabled"
+        }
+    });
+    s3StackTemplate.hasResourceProperties('AWS::S3::BucketPolicy', {
+        "Bucket": {
+            "Ref": "OpenSearchS3Bucket2ED683CC"
+        },
+        "PolicyDocument": {
+            "Statement": [
+                {
+                    "Action": "s3:*",
+                    "Condition": {
+                        "Bool": {
+                            "aws:SecureTransport": "false"
+                        }
+                    },
+                    "Effect": "Deny",
+                    "Principal": {
+                        "AWS": "*"
+                    },
+                    "Resource": [
+                        {
+                            "Fn::GetAtt": [
+                                "OpenSearchS3Bucket2ED683CC",
+                                "Arn"
+                            ]
+                        },
+                        {
+                            "Fn::Join": [
+                                "",
+                                [
+                                    {
+                                        "Fn::GetAtt": [
+                                            "OpenSearchS3Bucket2ED683CC",
+                                            "Arn"
+                                        ]
+                                    },
+                                    "/*"
+                                ]
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "Version": "2012-10-17"
+        }
+    });
+
+});


### PR DESCRIPTION
### Description
Coming from https://github.com/opensearch-project/opensearch-metrics/issues/76
1. Added an S3 bucket
2. Added the automation app docker container to upload github events to s3
3. Added role for ec2 to write to s3.

### Issues Resolved
Part of https://github.com/opensearch-project/opensearch-metrics/issues/57

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
