### PR TITLE
Bump automation app to 0.1.12

### DIFF
--- a/infrastructure/lib/stacks/gitHubAutomationApp.ts
+++ b/infrastructure/lib/stacks/gitHubAutomationApp.ts
@@ -160,7 +160,7 @@ export class GitHubAutomationApp extends Stack {
             'sudo systemctl start docker',
             'sudo curl -L https://github.com/docker/compose/releases/latest/download/docker-compose-$(uname -s)-$(uname -m) -o /usr/local/sbin/docker-compose',
             'sudo chmod a+x /usr/local/sbin/docker-compose',
-            'git clone https://github.com/opensearch-project/automation-app.git --branch 0.1.10',
+            'git clone https://github.com/opensearch-project/automation-app.git --branch 0.1.12',
             `aws secretsmanager get-secret-value --secret-id ${secretName} --query SecretString --output text >> automation-app/.env`,
             'cd automation-app/docker',
             'PORT=8080 RESOURCE_CONFIG=configs/resources/opensearch-project-resource.yml OPERATION_CONFIG=configs/operations/github-merged-pulls-monitor.yml docker-compose -p github-merged-pulls-monitor up -d',


### PR DESCRIPTION
### Description
Coming from https://github.com/opensearch-project/automation-app/pull/27
Upgrade the automation app version to fix event name bug.

### Issues Resolved
Part of https://github.com/opensearch-project/opensearch-metrics/issues/76

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
