### PR TITLE
Fix to add manual default input to eventbridge rule

### DIFF
--- a/infrastructure/lib/stacks/s3EventIndexWorkflow.ts
+++ b/infrastructure/lib/stacks/s3EventIndexWorkflow.ts
@@ -7,7 +7,7 @@
  */
 
 import { Duration, Stack, StackProps } from "aws-cdk-lib";
-import { Rule, Schedule } from "aws-cdk-lib/aws-events";
+import {Rule, RuleTargetInput, Schedule} from "aws-cdk-lib/aws-events";
 import { SfnStateMachine } from "aws-cdk-lib/aws-events-targets";
 import {JsonPath, StateMachine, TaskInput} from "aws-cdk-lib/aws-stepfunctions";
 import { LambdaInvoke } from "aws-cdk-lib/aws-stepfunctions-tasks";
@@ -46,10 +46,13 @@ export class OpenSearchS3EventIndexWorkflowStack extends Stack {
             stateMachineName: 'OpenSearchS3EventIndexWorkflow'
         })
 
-        new Rule(this, 'OpenSearchS3EventIndexWorkflow-Every-Day', {
+        const rule = new Rule(this, 'OpenSearchS3EventIndexWorkflow-Every-Day', {
             schedule: Schedule.expression('cron(0 0 * * ? *)'),
-            targets: [new SfnStateMachine(opensearchS3EventIndexWorkflow)],
         });
+
+        rule.addTarget(new SfnStateMachine(opensearchS3EventIndexWorkflow, {
+            input: RuleTargetInput.fromObject({}),
+        }));
 
         this.workflowComponent = {
             opensearchS3EventIndexWorkflowStateMachineName: opensearchS3EventIndexWorkflow.stateMachineName

--- a/infrastructure/test/s3-event-index-workflow-stack.test.ts
+++ b/infrastructure/test/s3-event-index-workflow-stack.test.ts
@@ -76,4 +76,24 @@ test('S3 Event Index Workflow Stack Test', () => {
         },
         "StateMachineName": "OpenSearchS3EventIndexWorkflow"
     });
+    template.resourceCountIs('AWS::Events::Rule', 1);
+    template.hasResourceProperties('AWS::Events::Rule', {
+        "ScheduleExpression": "cron(0 0 * * ? *)",
+        "State": "ENABLED",
+        "Targets": [
+            {
+                "Arn": {
+                    "Ref": "OpenSearchS3EventIndexWorkflow0C74BA9F"
+                },
+                "Id": "Target0",
+                "Input": "{}",
+                "RoleArn": {
+                    "Fn::GetAtt": [
+                        "OpenSearchS3EventIndexWorkflowEventsRole9EDAA508",
+                        "Arn"
+                    ]
+                }
+            }
+        ]
+    });
 });


### PR DESCRIPTION
### Description
The EventBridge Rule was passing matching input to the s3 event index lambda causing errors. The s3 event index lambda requires an input of `{}` to default to yesterday, so this change adds this input to the EventBridge Rule.

### Issues Resolved
Part of https://github.com/opensearch-project/opensearch-metrics/issues/76

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
