### PR TITLE
Onboard repo code coverage metrics

### DIFF
--- a/.github/workflows/cdk-ci-test.yml
+++ b/.github/workflows/cdk-ci-test.yml
@@ -14,6 +14,12 @@ jobs:
         with:
           node-version: '20.8.0'
 
+      - name: Setup Java 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'corretto'
+          java-version: '17'
+
       - name: Run CDK Test
         run: |
           ./gradlew clean build

--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,8 @@ dependencies {
 
     implementation 'software.amazon.awssdk:s3:2.28.17'
 
+    implementation 'org.json:json:20240303'
+
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.1'
 

--- a/src/main/java/org/opensearchmetrics/dagger/MetricsModule.java
+++ b/src/main/java/org/opensearchmetrics/dagger/MetricsModule.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
 package org.opensearchmetrics.dagger;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -5,6 +14,7 @@ import dagger.Module;
 import dagger.Provides;
 import org.opensearchmetrics.metrics.general.*;
 import org.opensearchmetrics.metrics.label.LabelMetrics;
+import org.opensearchmetrics.metrics.release.CodeCoverage;
 import org.opensearchmetrics.metrics.release.ReleaseBranchChecker;
 import org.opensearchmetrics.metrics.release.ReleaseIssueChecker;
 import org.opensearchmetrics.metrics.release.ReleaseLabelIssuesFetcher;
@@ -144,7 +154,9 @@ public class MetricsModule {
     public ReleaseMetrics getReleaseMetrics(OpenSearchUtil openSearchUtil, ObjectMapper objectMapper,
                                             ReleaseRepoFetcher releaseRepoFetcher, ReleaseLabelIssuesFetcher releaseLabelIssuesFetcher,
                                             ReleaseLabelPullsFetcher releaseLabelPullsFetcher, ReleaseVersionIncrementChecker releaseVersionIncrementChecker,
-                                            ReleaseBranchChecker releaseBranchChecker, ReleaseNotesChecker releaseNotesChecker, ReleaseIssueChecker releaseIssueChecker) {
-        return new ReleaseMetrics(openSearchUtil, objectMapper, releaseRepoFetcher, releaseLabelIssuesFetcher, releaseLabelPullsFetcher, releaseVersionIncrementChecker, releaseBranchChecker, releaseNotesChecker, releaseIssueChecker);
+                                            ReleaseBranchChecker releaseBranchChecker, ReleaseNotesChecker releaseNotesChecker, ReleaseIssueChecker releaseIssueChecker, CodeCoverage codeCoverage) {
+        return new ReleaseMetrics(openSearchUtil, objectMapper, releaseRepoFetcher,
+                releaseLabelIssuesFetcher, releaseLabelPullsFetcher, releaseVersionIncrementChecker,
+                releaseBranchChecker, releaseNotesChecker, releaseIssueChecker, codeCoverage);
     }
 }

--- a/src/main/java/org/opensearchmetrics/lambda/MetricsLambda.java
+++ b/src/main/java/org/opensearchmetrics/lambda/MetricsLambda.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
 package org.opensearchmetrics.lambda;
 
 import com.amazonaws.services.lambda.runtime.Context;
@@ -56,6 +65,7 @@ public class MetricsLambda extends AbstractBaseLambda {
             metricsCalculation.generateGeneralMetrics(keys);
             metricsCalculation.generateLabelMetrics(keys);
             metricsCalculation.generateReleaseMetrics();
+            metricsCalculation.generateCodeCovMetrics();
         } catch (Exception e) {
             throw new RuntimeException("Error running Metrics Calculation", e);
         }

--- a/src/main/java/org/opensearchmetrics/metrics/release/CodeCoverage.java
+++ b/src/main/java/org/opensearchmetrics/metrics/release/CodeCoverage.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearchmetrics.metrics.release;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.apache.http.util.EntityUtils;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.opensearchmetrics.model.codecov.CodeCovResponse;
+
+import javax.inject.Inject;
+import java.io.IOException;
+import java.util.Optional;
+
+public class CodeCoverage {
+    private final CloseableHttpClient httpClient;
+
+    @Inject
+    public CodeCoverage() {
+        this(HttpClients.createDefault());
+    }
+
+    @VisibleForTesting
+    CodeCoverage(CloseableHttpClient httpClient) {
+        this.httpClient = httpClient;
+    }
+
+    public CodeCovResponse coverage(String branch, String repo) {
+        String codeCovRepoURL = String.format("https://api.codecov.io/api/v2/github/opensearch-project/repos/%s/commits?branch=%s", repo, branch);
+        CodeCovResponse codeCovResponse = new CodeCovResponse();
+        codeCovResponse.setUrl(codeCovRepoURL);
+        HttpGet request = new HttpGet(codeCovRepoURL);
+        CloseableHttpResponse response;
+        try {
+            response = httpClient.execute(request);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        try {
+            if (response.getStatusLine().getStatusCode() == 200) {
+                String codeCovApiResult;
+                try {
+                    codeCovApiResult = EntityUtils.toString(response.getEntity());
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+                JSONObject jsonObject = new JSONObject(codeCovApiResult);
+                JSONArray resultsCoverage = jsonObject.getJSONArray("results");
+                Optional<JSONObject> firstResult = Optional.ofNullable(resultsCoverage)
+                        .filter(results -> results.length() > 0)
+                        .map(results -> results.getJSONObject(0));
+                firstResult.ifPresentOrElse(
+                        result -> {
+                            codeCovResponse.setState(Optional.ofNullable(result.optString("state"))
+                                    .orElse("no-coverage"));
+                            codeCovResponse.setCommitId(result.optString("commitid", "none"));
+                            codeCovResponse.setCoverage(
+                                    Optional.ofNullable(result.optJSONObject("totals"))
+                                            .map(totals -> totals.optDouble("coverage", 0.0))
+                                            .orElse(0.0)
+                            );
+                        },
+                        () -> {
+                            codeCovResponse.setState("no-coverage");
+                            codeCovResponse.setCommitId("none");
+                            codeCovResponse.setCoverage(0.0);
+                        }
+                );
+            }
+        } finally {
+            try {
+                response.close();
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return codeCovResponse;
+    }
+}

--- a/src/main/java/org/opensearchmetrics/metrics/release/ReleaseMetrics.java
+++ b/src/main/java/org/opensearchmetrics/metrics/release/ReleaseMetrics.java
@@ -1,9 +1,22 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
 package org.opensearchmetrics.metrics.release;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.opensearchmetrics.model.codecov.CodeCovResponse;
+import org.opensearchmetrics.model.codecov.CodeCovResult;
 import org.opensearchmetrics.util.OpenSearchUtil;
 
 import javax.inject.Inject;
+import java.io.IOException;
+import java.nio.charset.CoderResult;
 import java.util.List;
 import java.util.Map;
 
@@ -24,11 +37,13 @@ public class ReleaseMetrics {
 
     private final ReleaseIssueChecker releaseIssueChecker;
 
+    private final CodeCoverage codeCoverage;
+
     @Inject
     public ReleaseMetrics(OpenSearchUtil openSearchUtil, ObjectMapper objectMapper, ReleaseRepoFetcher releaseRepoFetcher,
                           ReleaseLabelIssuesFetcher releaseLabelIssuesFetcher, ReleaseLabelPullsFetcher releaseLabelPullsFetcher,
                           ReleaseVersionIncrementChecker releaseVersionIncrementChecker, ReleaseBranchChecker releaseBranchChecker,
-                          ReleaseNotesChecker releaseNotesChecker, ReleaseIssueChecker releaseIssueChecker) {
+                          ReleaseNotesChecker releaseNotesChecker, ReleaseIssueChecker releaseIssueChecker, CodeCoverage codeCoverage) {
         this.openSearchUtil = openSearchUtil;
         this.objectMapper = objectMapper;
         this.releaseRepoFetcher = releaseRepoFetcher;
@@ -38,6 +53,7 @@ public class ReleaseMetrics {
         this.releaseBranchChecker = releaseBranchChecker;
         this.releaseNotesChecker = releaseNotesChecker;
         this.releaseIssueChecker = releaseIssueChecker;
+        this.codeCoverage = codeCoverage;
     }
 
     public Map<String, String> getReleaseRepos(String releaseVersion) {
@@ -71,6 +87,10 @@ public class ReleaseMetrics {
 
     public String getReleaseIssue (String releaseVersion, String repo) {
         return releaseIssueChecker.releaseIssue(releaseVersion, repo, openSearchUtil);
+    }
+
+    public CodeCovResponse getCodeCoverage (String branch, String repo) {
+        return codeCoverage.coverage(branch, repo);
     }
 
 

--- a/src/main/java/org/opensearchmetrics/metrics/release/ReleaseVersionIncrementChecker.java
+++ b/src/main/java/org/opensearchmetrics/metrics/release/ReleaseVersionIncrementChecker.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
 package org.opensearchmetrics.metrics.release;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -35,6 +44,7 @@ public class ReleaseVersionIncrementChecker {
             return checkGithubPulls(repo, releaseVersion, objectMapper, openSearchUtil);
         }
     }
+
 
     public boolean checkOpenSearchVersion(String releaseVersion, String branch) {
         String url = String.format("https://raw.githubusercontent.com/opensearch-project/OpenSearch/%s/buildSrc/version.properties", branch);

--- a/src/main/java/org/opensearchmetrics/model/codecov/CodeCovResponse.java
+++ b/src/main/java/org/opensearchmetrics/model/codecov/CodeCovResponse.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearchmetrics.model.codecov;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import lombok.Data;
+
+import java.io.IOException;
+
+@Data
+public class CodeCovResponse {
+
+    @JsonProperty("commitid")
+    private String commitId;
+
+    @JsonProperty("url")
+    private String url;
+
+    @JsonProperty("state")
+    private String state;
+
+
+    @JsonSerialize(using = CodeCovDoubleSerializer.class)
+    @JsonProperty("coverage")
+    private Double coverage;
+}
+
+class CodeCovDoubleSerializer extends JsonSerializer<Double> {
+
+    @Override
+    public void serialize(Double value, JsonGenerator jsonGenerator, SerializerProvider serializerProvider)
+            throws IOException {
+        if (value == null) {
+            jsonGenerator.writeNumber(0.0);
+        } else {
+            jsonGenerator.writeNumber(value);
+        }
+    }
+}

--- a/src/main/java/org/opensearchmetrics/model/codecov/CodeCovResult.java
+++ b/src/main/java/org/opensearchmetrics/model/codecov/CodeCovResult.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearchmetrics.model.codecov;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.Data;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+@Data
+public class CodeCovResult {
+
+    @JsonProperty("id")
+    private String id;
+
+    @JsonProperty("current_date")
+    private String currentDate;
+
+    @JsonProperty("repository")
+    private String repository;
+
+    @JsonProperty("component")
+    private String component;
+
+    @JsonProperty("release_version")
+    private String releaseVersion;
+
+    @JsonProperty("release_state")
+    private String releaseState;
+
+    @JsonProperty("version")
+    private String version;
+
+    @JsonProperty("timestamp")
+    private String timestamp;
+
+    @JsonProperty("commitid")
+    private String commitId;
+
+    @JsonProperty("state")
+    private String state;
+
+    @JsonProperty("coverage")
+    private Double coverage;
+
+    @JsonProperty("branch")
+    private String branch;
+
+    @JsonProperty("url")
+    private String url;
+
+
+    public String toJson(ObjectMapper mapper) throws JsonProcessingException {
+        Map<String, Object> data = new HashMap<>();
+        data.put("id", id);
+        data.put("current_date", currentDate);
+        data.put("repository", repository);
+        data.put("component", component);
+        data.put("release_version", releaseVersion);
+        data.put("version", version);
+        data.put("release_state", releaseState);
+        data.put("commitid", commitId);
+        data.put("state", state);
+        data.put("coverage", coverage);
+        data.put("branch", branch);
+        data.put("url", url);
+        return mapper.writeValueAsString(data);
+    }
+
+    public String getJson(CodeCovResult codeCovResult, ObjectMapper objectMapper) {
+        try {
+            return codeCovResult.toJson(objectMapper);
+        } catch (JsonProcessingException e) {
+            System.out.println("Error while serializing ReportDataRow to JSON " +  e);
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/org/opensearchmetrics/model/release/ReleaseMetricsData.java
+++ b/src/main/java/org/opensearchmetrics/model/release/ReleaseMetricsData.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
 package org.opensearchmetrics.model.release;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -6,7 +15,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.Data;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 @Data
@@ -38,6 +46,7 @@ public class ReleaseMetricsData {
 
     @JsonProperty("autocut_issues_open")
     private Long autocutIssuesOpen;
+
     @JsonProperty("issues_closed")
     private Long issuesClosed;
 

--- a/src/test/java/org/opensearchmetrics/metrics/release/CodeCoverageTest.java
+++ b/src/test/java/org/opensearchmetrics/metrics/release/CodeCoverageTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearchmetrics.metrics.release;
+
+import org.apache.http.HttpEntity;
+import org.apache.http.StatusLine;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.opensearchmetrics.model.codecov.CodeCovResponse;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class CodeCoverageTest {
+
+    @Mock
+    private CloseableHttpClient httpClient;
+
+    private CodeCoverage codeCoverage;
+
+    private final String validJsonResponse = """
+        {
+            "results": [{
+                "state": "complete",
+                "commitid": "abc123",
+                "totals": {
+                    "coverage": 85.5
+                }
+            }]
+        }
+        """;
+
+    private final String emptyResultsResponse = """
+        {
+            "results": []
+        }
+        """;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        codeCoverage = new CodeCoverage(httpClient);
+    }
+
+    @Test
+    void testDefaultConstructor() {
+        CodeCoverage defaultCodeCoverage = new CodeCoverage();
+        assertNotNull(defaultCodeCoverage);
+    }
+
+    @Test
+    void testSuccessfulCoverageRequest() throws IOException {
+        CloseableHttpResponse httpResponse = mock(CloseableHttpResponse.class);
+        StatusLine statusLine = mock(StatusLine.class);
+        HttpEntity httpEntity = mock(HttpEntity.class);
+        when(statusLine.getStatusCode()).thenReturn(200);
+        when(httpResponse.getStatusLine()).thenReturn(statusLine);
+        when(httpResponse.getEntity()).thenReturn(httpEntity);
+        when(httpEntity.getContent()).thenReturn(new ByteArrayInputStream(validJsonResponse.getBytes()));
+        when(httpClient.execute(any())).thenReturn(httpResponse);
+        CodeCovResponse response = codeCoverage.coverage("main", "test-repo");
+        assertNotNull(response);
+        assertEquals("complete", response.getState());
+        assertEquals("abc123", response.getCommitId());
+        assertEquals(85.5, response.getCoverage());
+        assertEquals("https://api.codecov.io/api/v2/github/opensearch-project/repos/test-repo/commits?branch=main",
+                response.getUrl());
+    }
+
+    @Test
+    void testEmptyResultsResponse() throws IOException {
+        CloseableHttpResponse httpResponse = mock(CloseableHttpResponse.class);
+        StatusLine statusLine = mock(StatusLine.class);
+        HttpEntity httpEntity = mock(HttpEntity.class);
+
+        when(statusLine.getStatusCode()).thenReturn(200);
+        when(httpResponse.getStatusLine()).thenReturn(statusLine);
+        when(httpResponse.getEntity()).thenReturn(httpEntity);
+        when(httpEntity.getContent()).thenReturn(new ByteArrayInputStream(emptyResultsResponse.getBytes()));
+        when(httpClient.execute(any())).thenReturn(httpResponse);
+        CodeCovResponse response = codeCoverage.coverage("main", "test-repo");
+        assertNotNull(response);
+        assertEquals("no-coverage", response.getState());
+        assertEquals("none", response.getCommitId());
+        assertEquals(0.0, response.getCoverage());
+    }
+
+    @Test
+    void testWithout200Response() throws IOException {
+        CloseableHttpResponse httpResponse = mock(CloseableHttpResponse.class);
+        StatusLine statusLine = mock(StatusLine.class);
+        when(statusLine.getStatusCode()).thenReturn(404);
+        when(httpResponse.getStatusLine()).thenReturn(statusLine);
+        when(httpClient.execute(any())).thenReturn(httpResponse);
+        CodeCovResponse response = codeCoverage.coverage("main", "test-repo");
+        assertNotNull(response);
+        assertNull(response.getState());
+        assertNull(response.getCommitId());
+        assertEquals(null, response.getCoverage());
+    }
+
+    @Test
+    void testEntityUtilsThrowsException() throws IOException {
+        CloseableHttpResponse httpResponse = mock(CloseableHttpResponse.class);
+        StatusLine statusLine = mock(StatusLine.class);
+        HttpEntity httpEntity = mock(HttpEntity.class);
+        when(statusLine.getStatusCode()).thenReturn(200);
+        when(httpResponse.getStatusLine()).thenReturn(statusLine);
+        when(httpResponse.getEntity()).thenReturn(httpEntity);
+        when(httpEntity.getContent()).thenThrow(new IOException("Error reading content"));
+        when(httpClient.execute(any())).thenReturn(httpResponse);
+        assertThrows(RuntimeException.class, () -> codeCoverage.coverage("main", "test-repo"));
+    }
+
+    @Test
+    void testHttpClientExecuteThrowsException() throws IOException {
+        when(httpClient.execute(any())).thenThrow(new IOException("Failed to execute request"));
+        assertThrows(RuntimeException.class, () -> codeCoverage.coverage("main", "test-repo"));
+    }
+
+    @Test
+    void testResponseCloseThrowsException() throws IOException {
+        CloseableHttpResponse httpResponse = mock(CloseableHttpResponse.class);
+        StatusLine statusLine = mock(StatusLine.class);
+        when(statusLine.getStatusCode()).thenReturn(404);
+        when(httpResponse.getStatusLine()).thenReturn(statusLine);
+        when(httpClient.execute(any())).thenReturn(httpResponse);
+        doThrow(new IOException("Failed to close response")).when(httpResponse).close();
+        assertThrows(RuntimeException.class, () -> codeCoverage.coverage("main", "test-repo"));
+    }
+}

--- a/src/test/java/org/opensearchmetrics/metrics/release/ReleaseMetricsTest.java
+++ b/src/test/java/org/opensearchmetrics/metrics/release/ReleaseMetricsTest.java
@@ -1,17 +1,28 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
 package org.opensearchmetrics.metrics.release;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.opensearchmetrics.model.codecov.CodeCovResponse;
 import org.opensearchmetrics.util.OpenSearchUtil;
 
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.when;
 
@@ -41,90 +52,114 @@ public class ReleaseMetricsTest {
     @Mock
     private ReleaseNotesChecker releaseNotesChecker;
 
-
     @Mock
     private ReleaseIssueChecker releaseIssueChecker;
 
+    @Mock
+    private CodeCoverage codeCoverage;
+
+    @InjectMocks
+    private ReleaseMetrics releaseMetrics;
+
+    private CodeCovResponse codeCovResponse;
+
+    @BeforeEach
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+        codeCovResponse = new CodeCovResponse();
+        codeCovResponse.setCommitId("abc123");
+        codeCovResponse.setUrl("https://sample-release-issue/100");
+        codeCovResponse.setState("success");
+        codeCovResponse.setCoverage(85.5);
+    }
+
     @Test
     public void testGetReleaseRepos() {
-        MockitoAnnotations.openMocks(this);
         Map<String, String> repos = Collections.singletonMap("testRepo", "testComponent");
         when(releaseRepoFetcher.getReleaseRepos(anyString())).thenReturn(repos);
-        Map<String, String> result = releaseRepoFetcher.getReleaseRepos("1.0.0");
+
+        Map<String, String> result = releaseMetrics.getReleaseRepos("1.0.0");
         assertEquals(repos, result);
     }
 
     @Test
     public void testGetReleaseNotes() {
-        MockitoAnnotations.openMocks(this);
-
         boolean expectedNotes = true;
         when(releaseNotesChecker.releaseNotes(anyString(), anyString(), anyString()))
                 .thenReturn(expectedNotes);
-        boolean result = releaseNotesChecker.releaseNotes("1.0.0", "testRepo", "1.0");
+
+        boolean result = releaseMetrics.getReleaseNotes("1.0.0", "testRepo", "1.0");
         assertEquals(expectedNotes, result);
     }
 
     @Test
     public void testGetReleaseLabelIssues() {
-        MockitoAnnotations.openMocks(this);
-
         long expectedIssuesCount = 10;
         when(releaseLabelIssuesFetcher.releaseLabelIssues(anyString(), anyString(), anyString(), anyBoolean(), any()))
                 .thenReturn(expectedIssuesCount);
 
-        long result = releaseLabelIssuesFetcher.releaseLabelIssues("1.0.0", "testRepo", "open", true, openSearchUtil);
-
+        long result = releaseMetrics.getReleaseLabelIssues("1.0.0", "testRepo", "open", true);
         assertEquals(expectedIssuesCount, result);
     }
 
     @Test
     public void testGetReleaseLabelPulls() {
-        MockitoAnnotations.openMocks(this);
         long expectedPullsCount = 5;
         when(releaseLabelPullsFetcher.releaseLabelPulls(anyString(), anyString(), anyString(), any()))
                 .thenReturn(expectedPullsCount);
-        long result = releaseLabelPullsFetcher.releaseLabelPulls("1.0.0", "testRepo", "open", openSearchUtil);
+
+        long result = releaseMetrics.getReleaseLabelPulls("1.0.0", "testRepo", "open");
         assertEquals(expectedPullsCount, result);
     }
 
     @Test
     public void testGetReleaseVersionIncrement() {
-        MockitoAnnotations.openMocks(this);
         boolean expectedIncrement = true;
         when(releaseVersionIncrementChecker.releaseVersionIncrement(anyString(), anyString(), anyString(), any(), any()))
                 .thenReturn(expectedIncrement);
-        boolean result = releaseVersionIncrementChecker.releaseVersionIncrement("1.0.0", "testRepo", "main", objectMapper, openSearchUtil);
+
+        boolean result = releaseMetrics.getReleaseVersionIncrement("1.0.0", "testRepo", "main");
         assertEquals(expectedIncrement, result);
     }
 
     @Test
     public void testGetReleaseBranch() {
-        MockitoAnnotations.openMocks(this);
         boolean expectedBranch = true;
         when(releaseBranchChecker.releaseBranch(anyString(), anyString()))
                 .thenReturn(expectedBranch);
-        boolean result = releaseBranchChecker.releaseBranch("1.0.0", "testRepo");
+
+        boolean result = releaseMetrics.getReleaseBranch("1.0.0", "testRepo");
         assertEquals(expectedBranch, result);
     }
 
     @Test
-    public void testGetReleaseOwner() {
-        MockitoAnnotations.openMocks(this);
-        String[] releaseOwners = new String[]{"sample_user_1"};
+    public void testGetReleaseOwners() {
+        String[] expectedOwners = new String[]{"sample_user_1"};
         when(releaseIssueChecker.releaseOwners(anyString(), anyString(), any()))
-                .thenReturn(releaseOwners);
-        String[] result = releaseIssueChecker.releaseOwners("1.0.0", "testRepo", openSearchUtil);
-        assertEquals(releaseOwners, result);
+                .thenReturn(expectedOwners);
+
+        String[] result = releaseMetrics.getReleaseOwners("1.0.0", "testRepo");
+        assertArrayEquals(expectedOwners, result);
     }
 
     @Test
     public void testGetReleaseIssue() {
-        MockitoAnnotations.openMocks(this);
-        String releaseIssue = "https://sample-release-issue/100";
+        String expectedIssue = "https://sample-release-issue/100";
         when(releaseIssueChecker.releaseIssue(anyString(), anyString(), any()))
-                .thenReturn(releaseIssue);
-        String result = releaseIssueChecker.releaseIssue("1.0.0", "testRepo", openSearchUtil);
-        assertEquals(releaseIssue, result);
+                .thenReturn(expectedIssue);
+
+        String result = releaseMetrics.getReleaseIssue("1.0.0", "testRepo");
+        assertEquals(expectedIssue, result);
+    }
+
+    @Test
+    public void testGetCodeCoverage() {
+        when(codeCoverage.coverage(anyString(), anyString())).thenReturn(codeCovResponse);
+
+        CodeCovResponse result = releaseMetrics.getCodeCoverage("2.18", "testRepo");
+        assertEquals("abc123", result.getCommitId());
+        assertEquals("https://sample-release-issue/100", result.getUrl());
+        assertEquals("success", result.getState());
+        assertEquals(85.5, result.getCoverage());
     }
 }

--- a/src/test/java/org/opensearchmetrics/metrics/release/ReleaseVersionIncrementCheckerTest.java
+++ b/src/test/java/org/opensearchmetrics/metrics/release/ReleaseVersionIncrementCheckerTest.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
 package org.opensearchmetrics.metrics.release;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -18,39 +27,25 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class ReleaseVersionIncrementCheckerTest {
     @Test
     void testReleaseVersionIncrement_OpenSearch() {
-        // Given
         String releaseVersion = "1.0.0";
         String branch = "main";
         ReleaseVersionIncrementChecker checker = new ReleaseVersionIncrementChecker();
-
-        // When
         boolean result = checker.releaseVersionIncrement(releaseVersion, "OpenSearch", branch, null, null);
-
-        // Then
         assertFalse(result);
     }
 
     @Test
     void testReleaseVersionIncrement_OpenSearchDashboards() throws IOException {
-        // Given
         String releaseVersion = "1.0.0";
         String branch = "main";
         String repo = "OpenSearch-Dashboards";
         ObjectMapper objectMapper = Mockito.mock(ObjectMapper.class);
-
-        // Mocking the behavior of objectMapper.readTree()
         JsonNodeFactory nodeFactory = JsonNodeFactory.instance;
         ObjectNode objectNode = nodeFactory.objectNode();
         objectNode.put("version", releaseVersion);
-
         Mockito.when(objectMapper.readTree(Mockito.anyString())).thenReturn(objectNode);
-
         ReleaseVersionIncrementChecker checker = new ReleaseVersionIncrementChecker();
-
-        // When
         boolean result = checker.releaseVersionIncrement(releaseVersion, repo, branch, objectMapper, null);
-
-        // Then
         assertTrue(result);
     }
 
@@ -58,22 +53,17 @@ public class ReleaseVersionIncrementCheckerTest {
 
     @Test
     void testReleaseVersionIncrement_GithubPulls() {
-        // Given
         String releaseVersion = "1.0.0";
         String repo = "some-repo";
         ObjectMapper objectMapper = Mockito.mock(ObjectMapper.class);
         OpenSearchUtil openSearchUtil = Mockito.mock(OpenSearchUtil.class);
         SearchResponse searchResponse = Mockito.mock(SearchResponse.class);
         SearchHits searchHits = Mockito.mock(SearchHits.class);
-        Mockito.when(searchHits.getHits()).thenReturn(new SearchHit[0]); // Empty array to avoid NPE
+        Mockito.when(searchHits.getHits()).thenReturn(new SearchHit[0]);
         Mockito.when(searchResponse.getHits()).thenReturn(searchHits);
         Mockito.when(openSearchUtil.search(Mockito.any())).thenReturn(searchResponse);
         ReleaseVersionIncrementChecker checker = new ReleaseVersionIncrementChecker();
-
-        // When
         boolean result = checker.releaseVersionIncrement(releaseVersion, repo, "main", objectMapper, openSearchUtil);
-
-        // Then
         assertFalse(result);
     }
 

--- a/src/test/java/org/opensearchmetrics/model/codecov/CodeCovDoubleSerializerTest.java
+++ b/src/test/java/org/opensearchmetrics/model/codecov/CodeCovDoubleSerializerTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearchmetrics.model.codecov;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.io.IOException;
+
+import static org.mockito.Mockito.verify;
+
+public class CodeCovDoubleSerializerTest {
+
+    @Mock
+    private JsonGenerator jsonGenerator;
+
+    @Mock
+    private SerializerProvider serializerProvider;
+
+    private CodeCovDoubleSerializer serializer;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        serializer = new CodeCovDoubleSerializer();
+    }
+
+    @Test
+    public void testSerializeNullValue() throws IOException {
+        serializer.serialize(null, jsonGenerator, serializerProvider);
+        verify(jsonGenerator).writeNumber(0.0);
+    }
+
+    @Test
+    public void testSerializeNonNullValue() throws IOException {
+        Double value = 85.5;
+        serializer.serialize(value, jsonGenerator, serializerProvider);
+        verify(jsonGenerator).writeNumber(85.5);
+    }
+
+    @Test
+    public void testSerializeZeroValue() throws IOException {
+        Double value = 0.0;
+        serializer.serialize(value, jsonGenerator, serializerProvider);
+        verify(jsonGenerator).writeNumber(0.0);
+    }
+}

--- a/src/test/java/org/opensearchmetrics/model/codecov/CodeCovResponseTest.java
+++ b/src/test/java/org/opensearchmetrics/model/codecov/CodeCovResponseTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearchmetrics.model.codecov;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class CodeCovResponseTest {
+
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper();
+        SimpleModule module = new SimpleModule();
+        module.addSerializer(Double.class, new CodeCovDoubleSerializer());
+        objectMapper.registerModule(module);
+    }
+
+    @Test
+    public void testSerializeNonNullCoverage() throws JsonProcessingException {
+        CodeCovResponse response = new CodeCovResponse();
+        response.setCommitId("abc123");
+        response.setUrl("https://sample.url");
+        response.setState("success");
+        response.setCoverage(85.5);
+        String json = objectMapper.writeValueAsString(response);
+        String expectedJson = "{\"commitid\":\"abc123\",\"url\":\"https://sample.url\",\"state\":\"success\",\"coverage\":85.5}";
+        assertEquals(expectedJson, json);
+    }
+
+    @Test
+    public void testSerializeZeroCoverage() throws JsonProcessingException {
+        CodeCovResponse response = new CodeCovResponse();
+        response.setCommitId("abc123");
+        response.setUrl("https://sample.url");
+        response.setState("success");
+        response.setCoverage(0.0);
+        String json = objectMapper.writeValueAsString(response);
+        String expectedJson = "{\"commitid\":\"abc123\",\"url\":\"https://sample.url\",\"state\":\"success\",\"coverage\":0.0}";
+        assertEquals(expectedJson, json);
+    }
+
+    @Test
+    public void testDeserializeResponse() throws JsonProcessingException {
+        String json = "{\"commitid\":\"abc123\",\"url\":\"https://sample.url\",\"state\":\"success\",\"coverage\":85.5}";
+        CodeCovResponse response = objectMapper.readValue(json, CodeCovResponse.class);
+        assertEquals("abc123", response.getCommitId());
+        assertEquals("https://sample.url", response.getUrl());
+        assertEquals("success", response.getState());
+        assertEquals(85.5, response.getCoverage());
+    }
+
+    @Test
+    public void testDeserializeNullCoverage() throws JsonProcessingException {
+        String json = "{\"commitid\":\"abc123\",\"url\":\"https://sample.url\",\"state\":\"success\",\"coverage\":null}";
+        CodeCovResponse response = objectMapper.readValue(json, CodeCovResponse.class);
+        assertEquals("abc123", response.getCommitId());
+        assertEquals("https://sample.url", response.getUrl());
+        assertEquals("success", response.getState());
+        assertEquals(null, response.getCoverage());
+    }
+}

--- a/src/test/java/org/opensearchmetrics/model/codecov/CodeCovResultTest.java
+++ b/src/test/java/org/opensearchmetrics/model/codecov/CodeCovResultTest.java
@@ -1,0 +1,233 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearchmetrics.model.codecov;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockitoAnnotations;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class CodeCovResultTest {
+
+    private ObjectMapper objectMapper;
+
+    private CodeCovResult codeCovResult;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        codeCovResult = new CodeCovResult();
+        objectMapper = new ObjectMapper();
+        SimpleModule module = new SimpleModule();
+        module.addSerializer(Double.class, new CodeCovDoubleSerializer());
+        objectMapper.registerModule(module);
+    }
+
+    @Test
+    public void testId() {
+        codeCovResult.setId("123");
+        assertEquals("123", codeCovResult.getId());
+    }
+
+    @Test
+    public void testCurrentDate() {
+        codeCovResult.setCurrentDate("2024-01-01");
+        assertEquals("2024-01-01", codeCovResult.getCurrentDate());
+    }
+
+    @Test
+    public void testRepository() {
+        codeCovResult.setRepository("test-repo");
+        assertEquals("test-repo", codeCovResult.getRepository());
+    }
+
+    @Test
+    public void testComponent() {
+        codeCovResult.setComponent("test-component");
+        assertEquals("test-component", codeCovResult.getComponent());
+    }
+
+    @Test
+    public void testReleaseVersion() {
+        codeCovResult.setReleaseVersion("2.0.0");
+        assertEquals("2.0.0", codeCovResult.getReleaseVersion());
+    }
+
+    @Test
+    public void testReleaseState() {
+        codeCovResult.setReleaseState("released");
+        assertEquals("released", codeCovResult.getReleaseState());
+    }
+
+    @Test
+    public void testVersion() {
+        codeCovResult.setVersion("1.0");
+        assertEquals("1.0", codeCovResult.getVersion());
+    }
+
+    @Test
+    public void testTimestamp() {
+        codeCovResult.setTimestamp("2024-01-01T12:00:00Z");
+        assertEquals("2024-01-01T12:00:00Z", codeCovResult.getTimestamp());
+    }
+
+    @Test
+    public void testCommitid() {
+        codeCovResult.setCommitId("abc123");
+        assertEquals("abc123", codeCovResult.getCommitId());
+    }
+
+    @Test
+    public void testState() {
+        codeCovResult.setState("success");
+        assertEquals("success", codeCovResult.getState());
+    }
+
+    @Test
+    public void testCoverage() {
+        codeCovResult.setCoverage(85.5);
+        assertEquals(85.5, codeCovResult.getCoverage());
+    }
+
+    @Test
+    public void testBranch() {
+        codeCovResult.setBranch("main");
+        assertEquals("main", codeCovResult.getBranch());
+    }
+
+    @Test
+    public void testUrl() {
+        codeCovResult.setUrl("https://example.com");
+        assertEquals("https://example.com", codeCovResult.getUrl());
+    }
+
+    @Test
+    public void testSerializeNonNullCoverage() throws JsonProcessingException {
+        CodeCovResult result = new CodeCovResult();
+        result.setId("1");
+        result.setCommitId("abc123");
+        result.setUrl("https://sample.url");
+        result.setState("success");
+        result.setCoverage(85.5);
+        result.setRepository("sample-repo");
+        String json = result.toJson(objectMapper);
+        ObjectMapper mapper = new ObjectMapper();
+        Map<String, Object> actualMap = mapper.readValue(json, new TypeReference<>() {});
+        Map<String, Object> expectedMap = mapper.readValue(
+                "{\"id\":\"1\"," +
+                        "\"current_date\":null," +
+                        "\"repository\":\"sample-repo\"," +
+                        "\"component\":null," +
+                        "\"release_version\":null," +
+                        "\"version\":null," +
+                        "\"release_state\":null," +
+                        "\"commitid\":\"abc123\"," +
+                        "\"state\":\"success\"," +
+                        "\"coverage\":85.5," +
+                        "\"branch\":null," +
+                        "\"url\":\"https://sample.url\"}",
+                new TypeReference<>() {
+                }
+        );
+        assertEquals(expectedMap, actualMap);
+    }
+
+    @Test
+    public void testSerializeZeroCoverage() throws JsonProcessingException {
+        CodeCovResult result = new CodeCovResult();
+        result.setId("2");
+        result.setCommitId("def456");
+        result.setUrl("https://sample2.url");
+        result.setState("failure");
+        result.setCoverage(0.0);
+        String json = result.toJson(objectMapper);
+        ObjectMapper mapper = new ObjectMapper();
+        Map<String, Object> actualMap = mapper.readValue(json, new TypeReference<Map<String, Object>>() {});
+        Map<String, Object> expectedMap = mapper.readValue(
+                "{\"id\":\"2\"," +
+                        "\"current_date\":null," +
+                        "\"repository\":null," +
+                        "\"component\":null," +
+                        "\"release_version\":null," +
+                        "\"version\":null," +
+                        "\"release_state\":null," +
+                        "\"commitid\":\"def456\"," +
+                        "\"state\":\"failure\"," +
+                        "\"coverage\":0.0," +
+                        "\"branch\":null," +
+                        "\"url\":\"https://sample2.url\"}",
+                new TypeReference<>() {
+                }
+        );
+        assertEquals(expectedMap, actualMap);
+    }
+
+    @Test
+    public void testDeserializeResult() throws JsonProcessingException {
+        String json = "{\"id\":\"3\",\"commitid\":\"ghi789\",\"url\":\"https://sample3.url\"," +
+                "\"state\":\"partial\",\"coverage\":90.0,\"repository\":\"test-repo\"}";
+        CodeCovResult result = objectMapper.readValue(json, CodeCovResult.class);
+        assertEquals("3", result.getId());
+        assertEquals("ghi789", result.getCommitId());
+        assertEquals("https://sample3.url", result.getUrl());
+        assertEquals("partial", result.getState());
+        assertEquals(90.0, result.getCoverage());
+        assertEquals("test-repo", result.getRepository());
+    }
+
+    @Test
+    public void testDeserializeNullCoverage() throws JsonProcessingException {
+        String json = "{\"id\":\"4\",\"commitid\":\"jkl012\",\"url\":\"https://sample4.url\"," +
+                "\"state\":\"error\",\"coverage\":null}";
+        CodeCovResult result = objectMapper.readValue(json, CodeCovResult.class);
+        assertEquals("4", result.getId());
+        assertEquals("jkl012", result.getCommitId());
+        assertEquals("https://sample4.url", result.getUrl());
+        assertEquals("error", result.getState());
+        assertNull(result.getCoverage());
+    }
+
+    @Test
+    public void testGetJsonWithValidData() throws JsonProcessingException {
+        CodeCovResult result = new CodeCovResult();
+        result.setId("5");
+        result.setCommitId("mno345");
+        result.setUrl("https://sample5.url");
+        result.setState("completed");
+        result.setCoverage(75.0);
+        String json = result.getJson(result, objectMapper);
+        ObjectMapper mapper = new ObjectMapper();
+        Map<String, Object> actualMap = mapper.readValue(json, new TypeReference<Map<String, Object>>() {});
+        Map<String, Object> expectedMap = mapper.readValue(
+                "{\"id\":\"5\"," +
+                        "\"current_date\":null," +
+                        "\"repository\":null," +
+                        "\"component\":null," +
+                        "\"release_version\":null," +
+                        "\"version\":null," +
+                        "\"release_state\":null," +
+                        "\"commitid\":\"mno345\"," +
+                        "\"state\":\"completed\"," +
+                        "\"coverage\":75.0," +
+                        "\"branch\":null," +
+                        "\"url\":\"https://sample5.url\"}",
+                new TypeReference<>() {
+                }
+        );
+        assertEquals(expectedMap, actualMap);
+    }
+}


### PR DESCRIPTION
### Description
Onboard repo code coverage metrics and mechanism to link with existing release metrics.

```
"_source": {
    "coverage": 43.41,
    "current_date": "2024-10-28T17:54:41.742113549",
    "component": "customImportMapDashboards",
    "id": "b10b960e-b31f-3cb1-9a55-5e87ed2ade6b",
    "commitid": "511840ae5ca900610d521aad311677445269055f",
    "state": "complete",
    "repository": "dashboards-maps",
    "release_version": "2.18.0",
    "release_state": "open",
    "version": "2.18.0",
    "branch": "2.18",
    "url": "https://api.codecov.io/api/v2/github/opensearch-project/repos/dashboards-maps/commits?branch=2.18"
  },
```

```
  "_source": {
    "coverage": 0,
    "current_date": "2024-10-28T17:54:41.742113549",
    "component": "OpenSearch",
    "id": "09c026db-49b3-3502-ae80-717c6db4b8e1",
    "commitid": "none",
    "state": "no-coverage",
    "repository": "OpenSearch",
    "release_version": "2.18.0",
    "release_state": "open",
    "version": "2.18.0",
    "branch": "2.18",
    "url": "https://api.codecov.io/api/v2/github/opensearch-project/repos/OpenSearch/commits?branch=2.18"
  },
```

### Issues Resolved
Part of https://github.com/opensearch-project/opensearch-metrics/issues/51 and https://github.com/opensearch-project/opensearch-metrics/issues/90

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
