### PR TITLE
Added null checks for queried event fields

### DIFF
--- a/src/main/java/org/opensearchmetrics/metrics/maintainer/MaintainerMetrics.java
+++ b/src/main/java/org/opensearchmetrics/metrics/maintainer/MaintainerMetrics.java
@@ -98,8 +98,12 @@ public class MaintainerMetrics {
                 Map<String, Object> latestDocument = topHits.getHits().getHits()[0].getSourceAsMap();
                 LatestEventData latestEventData = new LatestEventData();
                 latestEventData.setEventType(eventType);
-                latestEventData.setEventAction(latestDocument.get("action").toString());
-                latestEventData.setTimeLastEngaged(Instant.parse(latestDocument.get("created_at").toString()));
+                if(latestDocument.containsKey("action")){
+                    latestEventData.setEventAction(latestDocument.get("action").toString());
+                }
+                if(latestDocument.containsKey("created_at")) {
+                    latestEventData.setTimeLastEngaged(Instant.parse(latestDocument.get("created_at").toString()));
+                }
                 return Optional.of(latestEventData);
             } else {
                 return Optional.empty();

--- a/src/test/java/org/opensearchmetrics/metrics/maintainer/MaintainerMetricsTest.java
+++ b/src/test/java/org/opensearchmetrics/metrics/maintainer/MaintainerMetricsTest.java
@@ -116,6 +116,42 @@ public class MaintainerMetricsTest {
     }
 
     @Test
+    public void testQueryLatestEventNoActionOrCreatedAt() {
+        // Mock
+        OpenSearchUtil openSearchUtil = Mockito.mock(OpenSearchUtil.class);
+        SearchResponse eventsResponse = Mockito.mock(SearchResponse.class);
+        SearchHit searchHit = Mockito.mock(SearchHit.class);
+        SearchHits searchHits = Mockito.mock(SearchHits.class);
+        TopHits topHits = Mockito.mock(TopHits.class);
+        Aggregations aggregations = Mockito.mock(Aggregations.class);
+
+        when(openSearchUtil.search(any(SearchRequest.class))).thenReturn(eventsResponse);
+        when(eventsResponse.status()).thenReturn(RestStatus.OK);
+        when(eventsResponse.getAggregations()).thenReturn(aggregations);
+        when(aggregations.get("latest_event")).thenReturn(topHits);
+        when(topHits.getHits()).thenReturn(searchHits);
+        when(searchHits.getHits()).thenReturn(new SearchHit[]{searchHit});
+
+        Map<String, Object> sourceMap = new HashMap<>();
+        when(searchHit.getSourceAsMap()).thenReturn(sourceMap);
+
+        MaintainerMetrics maintainerMetrics = new MaintainerMetrics();
+
+        // Call method under test
+        String testRepo = "testRepo";
+        String testUserLogin = "testUserLogin";
+        String testEventType = "testEventType";
+        Optional<LatestEventData> latestEvent = maintainerMetrics.queryLatestEvent(testRepo, testUserLogin, testEventType, openSearchUtil);
+        LatestEventData testEvent = new LatestEventData();
+        testEvent.setEventType("testEventType");
+        Optional<LatestEventData> testEventOpt = Optional.of(testEvent);
+
+
+        // Assertions
+        assertEquals(testEventOpt, latestEvent); // Modify expected result according to your logic
+    }
+
+    @Test
     public void testQueryLatestEventEmpty() {
         // Mock
         OpenSearchUtil openSearchUtil = Mockito.mock(OpenSearchUtil.class);


### PR DESCRIPTION
### Description
Fixed a bug with not having null checks for queried event fields.

### Issues Resolved
Part of https://github.com/opensearch-project/opensearch-metrics/issues/75

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
