### PR TITLE
Add unique github id check

### DIFF
--- a/src/main/java/org/opensearchmetrics/metrics/maintainer/MaintainerMetrics.java
+++ b/src/main/java/org/opensearchmetrics/metrics/maintainer/MaintainerMetrics.java
@@ -39,6 +39,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.HashSet;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -237,6 +239,7 @@ public class MaintainerMetrics {
         String rawMaintainersFile = String.format("https://raw.githubusercontent.com/opensearch-project/%s/main/MAINTAINERS.md", repo);
         boolean isEmeritusSection = false;
         List<MaintainerData> maintainersList = new ArrayList<>();
+        Set<String> maintainerIdSet = new HashSet<>();
         try (BufferedReader reader = new BufferedReader(new InputStreamReader(new URL(rawMaintainersFile).openStream(),
                 StandardCharsets.UTF_8))) {
             String line;
@@ -256,7 +259,10 @@ public class MaintainerMetrics {
                             maintainerData.setName(maintainer);
                             maintainerData.setGithubLogin(githubId);
                             maintainerData.setAffiliation(affiliation);
-                            maintainersList.add(maintainerData);
+                            if(!maintainerIdSet.contains(githubId)){ // Add only unique github ids
+                                maintainerIdSet.add(githubId);
+                                maintainersList.add(maintainerData);
+                            }
                         }
                     }
                 } else if (line.contains("Emeritus")) {

--- a/src/test/java/org/opensearchmetrics/metrics/maintainer/MaintainerMetricsTest.java
+++ b/src/test/java/org/opensearchmetrics/metrics/maintainer/MaintainerMetricsTest.java
@@ -287,6 +287,7 @@ public class MaintainerMetricsTest {
         String expectedContent = "test content\n" +
                 "| Maintainer       | GitHub ID                                | Affiliation |\n" +
                 "| maintainer | [githubId](https://github.com/githubId) | affiliation      |\n" +
+                "| maintainer | [githubId](https://github.com/githubId) | affiliation      |\n" +
                 "## Emeritus Maintainers" +
                 "| maintainer | [githubId](https://github.com/githubId) | affiliation      |\n" +
                 "line3\n";


### PR DESCRIPTION
### Description
Add unique github id check when scraping MAINTAINERS.md file in case of duplicate github ids.

### Issues Resolved
Part of https://github.com/opensearch-project/opensearch-metrics/issues/75

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
