### PR TITLE
Update ssl setting to support nginx/1.26.2

### DIFF
--- a/infrastructure/lib/constructs/opensearchNginxProxyCognito.ts
+++ b/infrastructure/lib/constructs/opensearchNginxProxyCognito.ts
@@ -176,12 +176,11 @@ export class OpenSearchMetricsNginxCognito extends Construct {
             resolver 10.0.0.2 ipv6=off;
             
             server {
-                listen 443;
+                listen 443 ssl;
                 server_name $host;
                 rewrite ^/$ https://$host/_dashboards redirect;
                 ssl_certificate /etc/nginx/cert.crt;
                 ssl_certificate_key /etc/nginx/cert.key;
-                ssl on;
                 ssl_session_cache builtin:1000 shared:SSL:10m;
                 ssl_protocols TLSv1.2 TLSv1.3;
                 ssl_ciphers HIGH:!aNULL:!eNULL:!EXPORT:!CAMELLIA:!DES:!MD5:!PSK:!RC4;

--- a/infrastructure/lib/stacks/opensearchNginxProxyReadonly.ts
+++ b/infrastructure/lib/stacks/opensearchNginxProxyReadonly.ts
@@ -162,12 +162,11 @@ export class OpenSearchMetricsNginxReadonly extends Stack {
             resolver 10.0.0.2 ipv6=off;
             
             server {
-                listen 443;
+                listen 443 ssl;
                 server_name $host;
                 rewrite ^/$ https://$host/_dashboards redirect;
                 ssl_certificate /etc/nginx/cert.crt;
                 ssl_certificate_key /etc/nginx/cert.key;
-                ssl on;
                 ssl_session_cache builtin:1000 shared:SSL:10m;
                 ssl_protocols TLSv1.2 TLSv1.3;
                 ssl_ciphers HIGH:!aNULL:!eNULL:!EXPORT:!CAMELLIA:!DES:!MD5:!PSK:!RC4;


### PR DESCRIPTION
### Description
Coming from https://futurestud.io/tutorials/nginx-how-to-fix-ssl-directive-is-deprecated-use-listen-ssl

### Issues Resolved
Part of https://github.com/opensearch-project/opensearch-metrics/issues/51

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
