### PR TITLE
Changed maintainer dashboard lambda to run at the start of UTC day

### DIFF
--- a/infrastructure/lib/stacks/maintainerInactivityWorkflow.ts
+++ b/infrastructure/lib/stacks/maintainerInactivityWorkflow.ts
@@ -45,7 +45,7 @@ export class OpenSearchMaintainerInactivityWorkflowStack extends Stack {
         })
 
         new Rule(this, 'MaintainerInactivityWorkflow-Every-Day', {
-            schedule: Schedule.expression('cron(15 0 * * ? *)'),
+            schedule: Schedule.expression('cron(0 0 * * ? *)'),
             targets: [new SfnStateMachine(opensearchMaintainerInactivityWorkflow)],
         });
 

--- a/infrastructure/lib/stacks/s3EventIndexWorkflow.ts
+++ b/infrastructure/lib/stacks/s3EventIndexWorkflow.ts
@@ -48,7 +48,7 @@ export class OpenSearchS3EventIndexWorkflowStack extends Stack {
         })
 
         const rule = new Rule(this, 'OpenSearchS3EventIndexWorkflow-Every-Day', {
-            schedule: Schedule.expression('cron(0 0 * * ? *)'),
+            schedule: Schedule.expression('cron(45 23 * * ? *)'),
         });
 
         rule.addTarget(new SfnStateMachine(opensearchS3EventIndexWorkflow, {

--- a/infrastructure/test/maintainer-inactivity-workflow-stack.test.ts
+++ b/infrastructure/test/maintainer-inactivity-workflow-stack.test.ts
@@ -76,4 +76,22 @@ test('Maintainer Inactivity Workflow Stack Test', () => {
         },
         "StateMachineName": "OpenSearchMaintainerInactivityWorkflow"
     });
+    template.hasResourceProperties('AWS::Events::Rule', {
+        "ScheduleExpression": "cron(0 0 * * ? *)",
+        "State": "ENABLED",
+        "Targets": [
+            {
+                "Arn": {
+                    "Ref": "OpenSearchMaintainerInactivityWorkflowE07E380B"
+                },
+                "Id": "Target0",
+                "RoleArn": {
+                    "Fn::GetAtt": [
+                        "OpenSearchMaintainerInactivityWorkflowEventsRole0FDEAE61",
+                        "Arn"
+                    ]
+                }
+            }
+        ]
+    });
 });

--- a/infrastructure/test/s3-event-index-workflow-stack.test.ts
+++ b/infrastructure/test/s3-event-index-workflow-stack.test.ts
@@ -79,7 +79,7 @@ test('S3 Event Index Workflow Stack Test', () => {
     });
     template.resourceCountIs('AWS::Events::Rule', 1);
     template.hasResourceProperties('AWS::Events::Rule', {
-        "ScheduleExpression": "cron(0 0 * * ? *)",
+        "ScheduleExpression": "cron(45 23 * * ? *)",
         "State": "ENABLED",
         "Targets": [
             {


### PR DESCRIPTION
### Description
Changed maintainer dashboard lambda to run at the start of UTC day

### Issues Resolved
Part of https://github.com/opensearch-project/opensearch-metrics/issues/57

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
