### PR TITLE
Changed latest event sender query from keyword field to text field

### DIFF
--- a/src/main/java/org/opensearchmetrics/metrics/maintainer/MaintainerMetrics.java
+++ b/src/main/java/org/opensearchmetrics/metrics/maintainer/MaintainerMetrics.java
@@ -82,7 +82,7 @@ public class MaintainerMetrics {
     public Optional<LatestEventData> queryLatestEvent(String repo, String userLogin, String eventType, OpenSearchUtil openSearchUtil) {
         BoolQueryBuilder boolQueryBuilder = QueryBuilders.boolQuery();
         boolQueryBuilder.must(QueryBuilders.matchQuery("repository.keyword", repo));
-        boolQueryBuilder.must(QueryBuilders.matchQuery("sender.keyword", userLogin));
+        boolQueryBuilder.must(QueryBuilders.matchQuery("sender", userLogin));
         boolQueryBuilder.must(QueryBuilders.matchQuery("type.keyword", eventType));
         SearchRequest searchRequest = new SearchRequest(GITHUB_EVENTS_INDEX);
         SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();


### PR DESCRIPTION
### Description
Fixing a bug in the Maintainer Dashboard where events are not found when the username in `MAINTAINER.md` and GitHub differ in case.

### Issues Resolved
Part of https://github.com/opensearch-project/opensearch-metrics/issues/57

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
