### PR TITLE
Changed s3 event index lambda to default index yesterday and today

### DIFF
--- a/src/main/java/org/opensearchmetrics/lambda/GithubEventsLambda.java
+++ b/src/main/java/org/opensearchmetrics/lambda/GithubEventsLambda.java
@@ -69,7 +69,7 @@ public class GithubEventsLambda implements RequestHandler<Map<String, String>, V
         }
         LocalDate collectionCurrentDate = collectionStartDate;
         LocalDate today = LocalDate.now(ZoneOffset.UTC);
-        while (collectionCurrentDate.isBefore(today)) {
+        while (!collectionCurrentDate.isAfter(today)) {
             Map<String, String> finalEventData = new HashMap<>();
             for (GithubEvents eventToIndex : eventsToIndex) {
                 String prefix = eventToIndex.getEventName() + "/" + collectionCurrentDate + "/";

--- a/src/test/java/org/opensearchmetrics/lambda/GithubEventsLambdaTest.java
+++ b/src/test/java/org/opensearchmetrics/lambda/GithubEventsLambdaTest.java
@@ -64,15 +64,19 @@ public class GithubEventsLambdaTest {
 
         Map<String,String> input = new HashMap<>();
         LocalDate yesterday = LocalDate.now(ZoneOffset.UTC).minus(1, ChronoUnit.DAYS);
+        LocalDate today = LocalDate.now(ZoneOffset.UTC);
         input.put("collectionStartDate", yesterday.toString());
 
         // Act
         githubEventsLambda.handleRequest(input, mock(Context.class));
 
         // Assert
-        String indexName = "github-user-activity-events-" + yesterday.format(DateTimeFormatter.ofPattern("MM-yyyy"));
-        verify(openSearchUtil).createIndexIfNotExists(indexName);
-        verify(openSearchUtil).bulkIndex(eq(indexName), any(Map.class));
+        String indexNameYesterday = "github-user-activity-events-" + yesterday.format(DateTimeFormatter.ofPattern("MM-yyyy"));
+        String indexNameToday = "github-user-activity-events-" + today.format(DateTimeFormatter.ofPattern("MM-yyyy"));
+        verify(openSearchUtil, atLeastOnce()).createIndexIfNotExists(indexNameYesterday);
+        verify(openSearchUtil, atLeastOnce()).createIndexIfNotExists(indexNameToday);
+        verify(openSearchUtil, atLeastOnce()).bulkIndex(eq(indexNameYesterday), any(Map.class));
+        verify(openSearchUtil, atLeastOnce()).bulkIndex(eq(indexNameToday), any(Map.class));
     }
 
     @Test
@@ -88,8 +92,8 @@ public class GithubEventsLambdaTest {
         when(s3Util.getObjectInputStream(anyString())).thenReturn(new ResponseInputStream<>(getObjectResponse, new ByteArrayInputStream(eventJson.getBytes())));
 
         Map<String,String> input = new HashMap<>();
-        LocalDate yesterday = LocalDate.now(ZoneOffset.UTC).minus(1, ChronoUnit.DAYS);
-        LocalDate lastMonth = yesterday.minus(1, ChronoUnit.MONTHS);
+        LocalDate today = LocalDate.now(ZoneOffset.UTC);
+        LocalDate lastMonth = today.minus(1, ChronoUnit.MONTHS);
         input.put("collectionStartDate", lastMonth.toString());
 
         // Act
@@ -100,7 +104,7 @@ public class GithubEventsLambdaTest {
         verify(openSearchUtil, atLeastOnce()).createIndexIfNotExists(indexNameLastMonth);
         verify(openSearchUtil, atLeastOnce()).bulkIndex(eq(indexNameLastMonth), any(Map.class));
 
-        String indexNameThisMonth = "github-user-activity-events-" + yesterday.format(DateTimeFormatter.ofPattern("MM-yyyy"));
+        String indexNameThisMonth = "github-user-activity-events-" + today.format(DateTimeFormatter.ofPattern("MM-yyyy"));
         verify(openSearchUtil, atLeastOnce()).createIndexIfNotExists(indexNameThisMonth);
         verify(openSearchUtil, atLeastOnce()).bulkIndex(eq(indexNameThisMonth), any(Map.class));
     }
@@ -119,14 +123,18 @@ public class GithubEventsLambdaTest {
 
         Map<String,String> input = new HashMap<>();
         LocalDate yesterday = LocalDate.now(ZoneOffset.UTC).minus(1, ChronoUnit.DAYS);
+        LocalDate today = LocalDate.now(ZoneOffset.UTC);
 
         // Act
         githubEventsLambda.handleRequest(input, mock(Context.class));
 
         // Assert
-        String indexName = "github-user-activity-events-" + yesterday.format(DateTimeFormatter.ofPattern("MM-yyyy"));
-        verify(openSearchUtil).createIndexIfNotExists(indexName);
-        verify(openSearchUtil).bulkIndex(eq(indexName), any(Map.class));
+        String indexNameYesterday = "github-user-activity-events-" + yesterday.format(DateTimeFormatter.ofPattern("MM-yyyy"));
+        String indexNameToday = "github-user-activity-events-" + today.format(DateTimeFormatter.ofPattern("MM-yyyy"));
+        verify(openSearchUtil, atLeastOnce()).createIndexIfNotExists(indexNameYesterday);
+        verify(openSearchUtil, atLeastOnce()).createIndexIfNotExists(indexNameToday);
+        verify(openSearchUtil, atLeastOnce()).bulkIndex(eq(indexNameYesterday), any(Map.class));
+        verify(openSearchUtil, atLeastOnce()).bulkIndex(eq(indexNameToday), any(Map.class));
     }
 
     @Test


### PR DESCRIPTION
### Description
Eventbridge rule calls the lambda function at the end of the day, so by changing the default to indexing yesterday AND today's events, we can get the most recent data for the maintainer dashboard.

### Issues Resolved
Part of https://github.com/opensearch-project/opensearch-metrics/issues/76 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
