### PR TITLE
Upgraded opensearch-high-level-rest-client to 2.18.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     implementation 'com.google.dagger:dagger:2.51'
     annotationProcessor 'com.google.dagger:dagger-compiler:2.51'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.3'
-    implementation 'org.opensearch.client:opensearch-rest-high-level-client:2.11.0'
+    implementation 'org.opensearch.client:opensearch-rest-high-level-client:2.18.0'
     implementation 'org.apache.httpcomponents.client5:httpclient5:5.2.1'
     implementation 'software.amazon.awssdk:sts:2.25.21'
     implementation 'io.github.acm19:aws-request-signing-apache-interceptor:2.3.1'


### PR DESCRIPTION
### Description
Upgraded opensearch-high-level-rest-client to 2.18.0

### Issues Resolved
Part of https://github.com/opensearch-project/opensearch-metrics/issues/80

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
