### PR TITLE
Fix version in release notes checker 

### DIFF
--- a/src/main/java/org/opensearchmetrics/metrics/MetricsCalculation.java
+++ b/src/main/java/org/opensearchmetrics/metrics/MetricsCalculation.java
@@ -191,7 +191,7 @@ public class MetricsCalculation {
                             releaseMetricsData.setPullsOpen(releaseMetrics.getReleaseLabelPulls(releaseInput.getVersion(), repoName, "open"));
                             releaseMetricsData.setPullsClosed(releaseMetrics.getReleaseLabelPulls(releaseInput.getVersion(), repoName, "closed"));
                             releaseMetricsData.setVersionIncrement(releaseMetrics.getReleaseVersionIncrement(releaseInput.getVersion(), repoName, releaseInput.getBranch()));
-                            releaseMetricsData.setReleaseNotes(releaseMetrics.getReleaseNotes(releaseInput.getVersion(), repoName, releaseInput.getBranch()));
+                            releaseMetricsData.setReleaseNotes(releaseMetrics.getReleaseNotes(releaseInput.getFullVersion(), repoName, releaseInput.getBranch()));
                             releaseMetricsData.setReleaseBranch(releaseMetrics.getReleaseBranch(releaseInput.getVersion(), repoName));
                             String[] releaseOwners = releaseMetrics.getReleaseOwners(releaseInput.getVersion(), repoName);
                             releaseMetricsData.setReleaseOwners(releaseOwners);

--- a/src/main/java/org/opensearchmetrics/metrics/MetricsCalculation.java
+++ b/src/main/java/org/opensearchmetrics/metrics/MetricsCalculation.java
@@ -167,7 +167,7 @@ public class MetricsCalculation {
         Map<String, String> metricFinalData =
                 Arrays.stream(releaseInputs)
                         .filter(ReleaseInputs::getTrack)
-                        .flatMap(releaseInput -> releaseMetrics.getReleaseRepos(releaseInput.getVersion()).entrySet().stream()
+                        .flatMap(releaseInput -> releaseMetrics.getReleaseRepos(releaseInput.getFullVersion()).entrySet().stream()
                         .flatMap(entry -> {
                             String repoName = entry.getKey();
                             String componentName = entry.getValue();
@@ -216,7 +216,7 @@ public class MetricsCalculation {
         Map<String, String> metricFinalData =
                 Arrays.stream(releaseInputs)
                         .filter(ReleaseInputs::getTrack)
-                        .flatMap(releaseInput -> releaseMetrics.getReleaseRepos(releaseInput.getVersion()).entrySet().stream()
+                        .flatMap(releaseInput -> releaseMetrics.getReleaseRepos(releaseInput.getFullVersion()).entrySet().stream()
                                 .flatMap(entry -> {
                                     String repoName = entry.getKey();
                                     String componentName = entry.getValue();

--- a/src/main/java/org/opensearchmetrics/metrics/release/ReleaseInputs.java
+++ b/src/main/java/org/opensearchmetrics/metrics/release/ReleaseInputs.java
@@ -9,7 +9,7 @@
 package org.opensearchmetrics.metrics.release;
 
 public enum ReleaseInputs {
-    VERSION_3_0_0("3.0.0", "open", "main", true),
+    VERSION_3_0_0("3.0.0-alpha1", "open", "main", true),
     VERSION_2_12_0("2.12.0", "closed", "2.12", false),
     VERSION_2_13_0("2.13.0", "closed", "2.13", false),
     VERSION_2_14_0("2.14.0", "closed", "2.14", false),
@@ -29,7 +29,6 @@ public enum ReleaseInputs {
     private final String version;
     private final String state;
     private final String branch;
-
     private final boolean track;
 
     ReleaseInputs(String version, String state, String branch, boolean track) {
@@ -40,6 +39,16 @@ public enum ReleaseInputs {
     }
 
     public String getVersion() {
+        String[] versionSplit = version.split("-");
+        return versionSplit[0];
+    }
+
+    public String getQualifier() {
+        String[] versionSplit = version.split("-");
+        return versionSplit.length > 1 ? versionSplit[1] : null;
+    }
+
+    public String getFullVersion() {
         return version;
     }
 

--- a/src/main/java/org/opensearchmetrics/metrics/release/ReleaseNotesChecker.java
+++ b/src/main/java/org/opensearchmetrics/metrics/release/ReleaseNotesChecker.java
@@ -22,12 +22,17 @@ public class ReleaseNotesChecker extends UrlResponse {
 
     public Boolean releaseNotes(String releaseVersion, String repo, String releaseBranch) {
         String releaseNotesUrl;
+        String[] versionSplit = releaseVersion.split("-");
+        String qualifier = versionSplit.length > 1 ? versionSplit[1] : null;
+
         if(repo.equals("OpenSearch")) {
             releaseNotesUrl = String.format("https://raw.githubusercontent.com/opensearch-project/%s/%s/release-notes/opensearch.release-notes-%s.md", repo, releaseBranch, releaseVersion);
         } else if (repo.equals("OpenSearch-Dashboards")) {
             releaseNotesUrl = String.format("https://raw.githubusercontent.com/opensearch-project/%s/%s/release-notes/opensearch-dashboards.release-notes-%s.md", repo, releaseBranch, releaseVersion);
-        } else {
+        } else if (qualifier == null){
             releaseNotesUrl = String.format("https://raw.githubusercontent.com/opensearch-project/%s/%s/release-notes/opensearch-%s.release-notes-%s.0.md", repo, releaseBranch, repo, releaseVersion);
+        } else {
+            releaseNotesUrl = String.format("https://raw.githubusercontent.com/opensearch-project/%s/%s/release-notes/opensearch-%s.release-notes-%s.0-%s.md", repo, releaseBranch, repo, releaseVersion, qualifier);
         }
         try {
             int responseCode = urlResponse.getUrlResponse(releaseNotesUrl).getResponseCode();

--- a/src/test/java/org/opensearchmetrics/metrics/MetricsCalculationTest.java
+++ b/src/test/java/org/opensearchmetrics/metrics/MetricsCalculationTest.java
@@ -166,7 +166,7 @@ public class MetricsCalculationTest {
     void testGenerateCodeCovMetrics() {
         try (MockedStatic<ReleaseInputs> mockedReleaseInputs = Mockito.mockStatic(ReleaseInputs.class)) {
             ReleaseInputs releaseInput = mock(ReleaseInputs.class);
-            when(releaseInput.getVersion()).thenReturn("2.18.0");
+            when(releaseInput.getFullVersion()).thenReturn("2.18.0");
             when(releaseInput.getBranch()).thenReturn("main");
             when(releaseInput.getTrack()).thenReturn(true);
             when(releaseInput.getState()).thenReturn("active");

--- a/src/test/java/org/opensearchmetrics/metrics/MetricsCalculationTest.java
+++ b/src/test/java/org/opensearchmetrics/metrics/MetricsCalculationTest.java
@@ -152,7 +152,7 @@ public class MetricsCalculationTest {
         when(releaseMetrics.getReleaseLabelPulls(ReleaseInputs.VERSION_2_13_0.getVersion(), "repo1", "open")).thenReturn(3L);
         when(releaseMetrics.getReleaseLabelPulls(ReleaseInputs.VERSION_2_13_0.getVersion(), "repo1", "closed")).thenReturn(8L);
         when(releaseMetrics.getReleaseVersionIncrement(ReleaseInputs.VERSION_2_13_0.getVersion(), "repo1", "main")).thenReturn(true);
-        when(releaseMetrics.getReleaseNotes(ReleaseInputs.VERSION_2_13_0.getVersion(), "repo1", "main")).thenReturn(true);
+        when(releaseMetrics.getReleaseNotes(ReleaseInputs.VERSION_2_13_0.getFullVersion(), "repo1", "main")).thenReturn(true);
         when(releaseMetrics.getReleaseBranch(ReleaseInputs.VERSION_2_13_0.getVersion(), "repo1")).thenReturn(true);
         when(releaseMetrics.getReleaseOwners(ReleaseInputs.VERSION_2_13_0.getVersion(), "repo1")).thenReturn(new String[]{"owner1", "owner2"});
         when(releaseMetrics.getReleaseIssue(ReleaseInputs.VERSION_2_13_0.getVersion(), "repo1")).thenReturn("release-123");

--- a/src/test/java/org/opensearchmetrics/metrics/release/ReleaseInputsTest.java
+++ b/src/test/java/org/opensearchmetrics/metrics/release/ReleaseInputsTest.java
@@ -37,11 +37,42 @@ public class ReleaseInputsTest {
     @Test
     public void testGetFullVersion() {
         assertEquals("3.0.0-alpha1", ReleaseInputs.VERSION_3_0_0.getFullVersion());
+        assertEquals("2.12.0", ReleaseInputs.VERSION_2_12_0.getFullVersion());
+        assertEquals("2.13.0", ReleaseInputs.VERSION_2_13_0.getFullVersion());
+        assertEquals("2.14.0", ReleaseInputs.VERSION_2_14_0.getFullVersion());
+        assertEquals("2.15.0", ReleaseInputs.VERSION_2_15_0.getFullVersion());
+        assertEquals("2.16.0", ReleaseInputs.VERSION_2_16_0.getFullVersion());
+        assertEquals("2.17.0", ReleaseInputs.VERSION_2_17_0.getFullVersion());
+        assertEquals("2.18.0", ReleaseInputs.VERSION_2_18_0.getFullVersion());
+        assertEquals("2.19.0", ReleaseInputs.VERSION_2_19_0.getFullVersion());
+        assertEquals("2.19.1", ReleaseInputs.VERSION_2_19_1.getFullVersion());
+        assertEquals("1.3.15", ReleaseInputs.VERSION_1_3_15.getFullVersion());
+        assertEquals("1.3.16", ReleaseInputs.VERSION_1_3_16.getFullVersion());
+        assertEquals("1.3.17", ReleaseInputs.VERSION_1_3_17.getFullVersion());
+        assertEquals("1.3.18", ReleaseInputs.VERSION_1_3_18.getFullVersion());
+        assertEquals("1.3.19", ReleaseInputs.VERSION_1_3_19.getFullVersion());
+        assertEquals("1.3.20", ReleaseInputs.VERSION_1_3_20.getFullVersion());
     }
 
     @Test
     public void testGetQualifier() {
         assertEquals("alpha1", ReleaseInputs.VERSION_3_0_0.getQualifier());
+        assertEquals(null, ReleaseInputs.VERSION_2_12_0.getQualifier());
+        assertEquals(null, ReleaseInputs.VERSION_2_13_0.getQualifier());
+        assertEquals(null, ReleaseInputs.VERSION_2_14_0.getQualifier());
+        assertEquals(null, ReleaseInputs.VERSION_2_15_0.getQualifier());
+        assertEquals(null, ReleaseInputs.VERSION_2_16_0.getQualifier());
+        assertEquals(null, ReleaseInputs.VERSION_2_17_0.getQualifier());
+        assertEquals(null, ReleaseInputs.VERSION_2_18_0.getQualifier());
+        assertEquals(null, ReleaseInputs.VERSION_2_19_0.getQualifier());
+        assertEquals(null, ReleaseInputs.VERSION_2_19_1.getQualifier());
+        assertEquals(null, ReleaseInputs.VERSION_1_3_15.getQualifier());
+        assertEquals(null, ReleaseInputs.VERSION_1_3_16.getQualifier());
+        assertEquals(null, ReleaseInputs.VERSION_1_3_17.getQualifier());
+        assertEquals(null, ReleaseInputs.VERSION_1_3_18.getQualifier());
+        assertEquals(null, ReleaseInputs.VERSION_1_3_19.getQualifier());
+        assertEquals(null, ReleaseInputs.VERSION_1_3_20.getQualifier());
+
     }
 
     @Test

--- a/src/test/java/org/opensearchmetrics/metrics/release/ReleaseInputsTest.java
+++ b/src/test/java/org/opensearchmetrics/metrics/release/ReleaseInputsTest.java
@@ -35,6 +35,16 @@ public class ReleaseInputsTest {
     }
 
     @Test
+    public void testGetFullVersion() {
+        assertEquals("3.0.0-alpha1", ReleaseInputs.VERSION_3_0_0.getFullVersion());
+    }
+
+    @Test
+    public void testGetQualifier() {
+        assertEquals("alpha1", ReleaseInputs.VERSION_3_0_0.getQualifier());
+    }
+
+    @Test
     public void testGetState() {
         assertEquals("open", ReleaseInputs.VERSION_3_0_0.getState());
         assertEquals("closed", ReleaseInputs.VERSION_2_12_0.getState());

--- a/src/test/java/org/opensearchmetrics/metrics/release/ReleaseNotesCheckerTest.java
+++ b/src/test/java/org/opensearchmetrics/metrics/release/ReleaseNotesCheckerTest.java
@@ -46,4 +46,17 @@ public class ReleaseNotesCheckerTest {
 
         assertFalse(releaseNotesChecker.releaseNotes("1.0", "OpenSearch", "1.0"));
     }
+
+    @Test
+    void testReleaseNotesExistWithQualifier() throws IOException {
+        // Mocking the getUrlResponse method of UrlResponse class
+        UrlResponse urlResponseMock = mock(UrlResponse.class);
+        HttpURLConnection connectionMock = mock(HttpURLConnection.class);
+        when(connectionMock.getResponseCode()).thenReturn(HttpURLConnection.HTTP_OK);
+        when(urlResponseMock.getUrlResponse(anyString())).thenReturn(connectionMock);
+
+        ReleaseNotesChecker releaseNotesChecker = new ReleaseNotesChecker(urlResponseMock);
+
+        assertTrue(releaseNotesChecker.releaseNotes("3.0.0-alpha1", "OpenSearch", "main"));
+    }
 }


### PR DESCRIPTION
### Description
As of now qualifier is only considered in the release notes from GitHub side of things. 
(No labels, issues, etc consider qualifier).
This PR adds a change to take qualifier into consideration. The getVersion() is still intact to return only the version and not `version-qualifier`. Added additional methods for retrieving that info.

### Issues Resolved
part of https://github.com/opensearch-project/opensearch-metrics/issues/121

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
