### PR TITLE
Switch values for components repo map

### DIFF
--- a/src/main/java/org/opensearchmetrics/metrics/MetricsCalculation.java
+++ b/src/main/java/org/opensearchmetrics/metrics/MetricsCalculation.java
@@ -169,8 +169,8 @@ public class MetricsCalculation {
                         .filter(ReleaseInputs::getTrack)
                         .flatMap(releaseInput -> releaseMetrics.getReleaseRepos(releaseInput.getVersion()).entrySet().stream()
                         .flatMap(entry -> {
-                            String repoName = entry.getKey();
-                            String componentName = entry.getValue();
+                            String repoName = entry.getValue();
+                            String componentName = entry.getKey();
                             ReleaseMetricsData releaseMetricsData = new ReleaseMetricsData();
                             releaseMetricsData.setRepository(repoName);
                             releaseMetricsData.setComponent(componentName);

--- a/src/main/java/org/opensearchmetrics/metrics/release/ReleaseRepoFetcher.java
+++ b/src/main/java/org/opensearchmetrics/metrics/release/ReleaseRepoFetcher.java
@@ -90,7 +90,7 @@ public class ReleaseRepoFetcher {
                             int endIndex = repoUrl.lastIndexOf(".git");
                             String repoName = (endIndex != -1) ? repoUrl.substring(startIndex, endIndex) : repoUrl.substring(startIndex);
 
-                            repoMap.put(repoName, componentName);
+                            repoMap.put(componentName, repoName);
                         });
             }
         });

--- a/src/test/java/org/opensearchmetrics/metrics/release/ReleaseMetricsTest.java
+++ b/src/test/java/org/opensearchmetrics/metrics/release/ReleaseMetricsTest.java
@@ -74,7 +74,7 @@ public class ReleaseMetricsTest {
 
     @Test
     public void testGetReleaseRepos() {
-        Map<String, String> repos = Collections.singletonMap("testRepo", "testComponent");
+        Map<String, String> repos = Collections.singletonMap("testComponent", "testRepo");
         when(releaseRepoFetcher.getReleaseRepos(anyString())).thenReturn(repos);
 
         Map<String, String> result = releaseMetrics.getReleaseRepos("1.0.0");

--- a/src/test/java/org/opensearchmetrics/metrics/release/ReleaseRepoFetcherTest.java
+++ b/src/test/java/org/opensearchmetrics/metrics/release/ReleaseRepoFetcherTest.java
@@ -97,7 +97,7 @@ public class ReleaseRepoFetcherTest {
         assertEquals(2, repoNames.size());
         Map<String, String> expectedRepoNames = new HashMap<>();
         expectedRepoNames.put("OpenSearch", "OpenSearch");
-        expectedRepoNames.put("common-utils", "commonUtils");
+        expectedRepoNames.put("commonUtils", "common-utils");
         assertEquals(expectedRepoNames, repoNames);
         // assertEquals(new ArrayList<>(Arrays.asList("OpenSearch", "common-utils")), repoNames);
     }


### PR DESCRIPTION
### Description
The current set up has below mapping:
```
<repository_name> : <component_name>
```
This causes an issue with multi-component repositories such as notifications and notifications core. 
We want to track per component rather than per repo. This PR switches the mapping to below:
```
<component_name>: <repository_name>
```

### Issues Resolved
https://github.com/opensearch-project/opensearch-build-libraries/issues/643
resolves https://github.com/opensearch-project/opensearch-metrics/issues/129

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
