### PR TITLE
Switch document ID from repo name to unique component name

### DIFF
--- a/src/main/java/org/opensearchmetrics/metrics/MetricsCalculation.java
+++ b/src/main/java/org/opensearchmetrics/metrics/MetricsCalculation.java
@@ -177,7 +177,7 @@ public class MetricsCalculation {
                             releaseMetricsData.setCurrentDate(currentDate.toString());
                             try {
                                 releaseMetricsData.setId(String.valueOf(UUID.nameUUIDFromBytes(MessageDigest.getInstance("SHA-1")
-                                        .digest(("release-metrics-" + releaseInput.getVersion() + "-" + currentDate.format(DateTimeFormatter.ofPattern("yyyy-MM-dd")) + "-" + repoName)
+                                        .digest(("release-metrics-" + releaseInput.getVersion() + "-" + currentDate.format(DateTimeFormatter.ofPattern("yyyy-MM-dd")) + "-" + componentName)
                                                 .getBytes()))));
                             } catch (NoSuchAlgorithmException e) {
                                 throw new RuntimeException(e);


### PR DESCRIPTION
### Description
Lamda throws an error that document already exists since the repo name is same. This PR fixes the documentID to componentName suffix.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
