### PR TITLE
Adds 3.2 version for tracking and closes 2.19.3

### DIFF
--- a/src/main/java/org/opensearchmetrics/metrics/release/ReleaseInputs.java
+++ b/src/main/java/org/opensearchmetrics/metrics/release/ReleaseInputs.java
@@ -9,6 +9,7 @@
 package org.opensearchmetrics.metrics.release;
 
 public enum ReleaseInputs {
+    VERSION_3_2_0("3.2.0", "open", "main", true),
     VERSION_3_1_0("3.1.0", "closed", "3.1", true),
     VERSION_3_0_0("3.0.0", "closed", "3.0", false),
     VERSION_2_12_0("2.12.0", "closed", "2.12", false),
@@ -21,7 +22,7 @@ public enum ReleaseInputs {
     VERSION_2_19_0("2.19.0", "closed", "2.19", false),
     VERSION_2_19_1("2.19.1", "closed", "2.19", false),
     VERSION_2_19_2("2.19.2", "closed", "2.19", false),
-    VERSION_2_19_3("2.19.3", "open", "2.19", true),
+    VERSION_2_19_3("2.19.3", "closed", "2.19", false),
     VERSION_1_3_15("1.3.15", "closed", "1.3", false),
     VERSION_1_3_16("1.3.16", "closed", "1.3", false),
     VERSION_1_3_17("1.3.17", "closed", "1.3", false),

--- a/src/test/java/org/opensearchmetrics/metrics/release/ReleaseInputsTest.java
+++ b/src/test/java/org/opensearchmetrics/metrics/release/ReleaseInputsTest.java
@@ -16,6 +16,7 @@ public class ReleaseInputsTest {
 
     @Test
     public void testGetVersion() {
+        assertEquals("3.2.0", ReleaseInputs.VERSION_3_2_0.getVersion());
         assertEquals("3.1.0", ReleaseInputs.VERSION_3_1_0.getVersion());
         assertEquals("3.1.0", ReleaseInputs.VERSION_3_1_0.getVersion());
         assertEquals("3.0.0", ReleaseInputs.VERSION_3_0_0.getVersion());
@@ -40,6 +41,7 @@ public class ReleaseInputsTest {
 
     @Test
     public void testGetState() {
+        assertEquals("open", ReleaseInputs.VERSION_3_2_0.getState());
         assertEquals("closed", ReleaseInputs.VERSION_3_1_0.getState());
         assertEquals("closed", ReleaseInputs.VERSION_3_0_0.getState());
         assertEquals("closed", ReleaseInputs.VERSION_2_12_0.getState());
@@ -52,7 +54,7 @@ public class ReleaseInputsTest {
         assertEquals("closed", ReleaseInputs.VERSION_2_19_0.getState());
         assertEquals("closed", ReleaseInputs.VERSION_2_19_1.getState());
         assertEquals("closed", ReleaseInputs.VERSION_2_19_2.getState());
-        assertEquals("open", ReleaseInputs.VERSION_2_19_3.getState());
+        assertEquals("closed", ReleaseInputs.VERSION_2_19_3.getState());
         assertEquals("closed", ReleaseInputs.VERSION_1_3_15.getState());
         assertEquals("closed", ReleaseInputs.VERSION_1_3_16.getState());
         assertEquals("closed", ReleaseInputs.VERSION_1_3_17.getState());
@@ -63,6 +65,7 @@ public class ReleaseInputsTest {
 
     @Test
     public void testGetBranch() {
+        assertEquals("main", ReleaseInputs.VERSION_3_2_0.getBranch());
         assertEquals("3.1", ReleaseInputs.VERSION_3_1_0.getBranch());
         assertEquals("3.0", ReleaseInputs.VERSION_3_0_0.getBranch());
         assertEquals("2.12", ReleaseInputs.VERSION_2_12_0.getBranch());
@@ -86,6 +89,7 @@ public class ReleaseInputsTest {
 
     @Test
     public void testGetTrack() {
+        assertEquals(true, ReleaseInputs.VERSION_3_2_0.getTrack());
         assertEquals(true, ReleaseInputs.VERSION_3_1_0.getTrack());
         assertEquals(false, ReleaseInputs.VERSION_3_0_0.getTrack());
         assertEquals(false, ReleaseInputs.VERSION_2_12_0.getTrack());
@@ -98,7 +102,7 @@ public class ReleaseInputsTest {
         assertEquals(false, ReleaseInputs.VERSION_2_19_0.getTrack());
         assertEquals(false, ReleaseInputs.VERSION_2_19_1.getTrack());
         assertEquals(false, ReleaseInputs.VERSION_2_19_2.getTrack());
-        assertEquals(true, ReleaseInputs.VERSION_2_19_3.getTrack());
+        assertEquals(false, ReleaseInputs.VERSION_2_19_3.getTrack());
         assertEquals(false, ReleaseInputs.VERSION_1_3_15.getTrack());
         assertEquals(false, ReleaseInputs.VERSION_1_3_16.getTrack());
         assertEquals(false, ReleaseInputs.VERSION_1_3_17.getTrack());
@@ -110,26 +114,27 @@ public class ReleaseInputsTest {
     @Test
     public void testGetAllReleaseInputs() {
         ReleaseInputs[] releaseInputs = ReleaseInputs.getAllReleaseInputs();
-        assertEquals(19, releaseInputs.length);
-        assertEquals(ReleaseInputs.VERSION_3_1_0, releaseInputs[0]);
-        assertEquals(ReleaseInputs.VERSION_3_0_0, releaseInputs[1]);
-        assertEquals(ReleaseInputs.VERSION_2_12_0, releaseInputs[2]);
-        assertEquals(ReleaseInputs.VERSION_2_13_0, releaseInputs[3]);
-        assertEquals(ReleaseInputs.VERSION_2_14_0, releaseInputs[4]);
-        assertEquals(ReleaseInputs.VERSION_2_15_0, releaseInputs[5]);
-        assertEquals(ReleaseInputs.VERSION_2_16_0, releaseInputs[6]);
-        assertEquals(ReleaseInputs.VERSION_2_17_0, releaseInputs[7]);
-        assertEquals(ReleaseInputs.VERSION_2_18_0, releaseInputs[8]);
-        assertEquals(ReleaseInputs.VERSION_2_19_0, releaseInputs[9]);
-        assertEquals(ReleaseInputs.VERSION_2_19_1, releaseInputs[10]);
-        assertEquals(ReleaseInputs.VERSION_2_19_2, releaseInputs[11]);
-        assertEquals(ReleaseInputs.VERSION_2_19_3, releaseInputs[12]);
-        assertEquals(ReleaseInputs.VERSION_1_3_15, releaseInputs[13]);
-        assertEquals(ReleaseInputs.VERSION_1_3_16, releaseInputs[14]);
-        assertEquals(ReleaseInputs.VERSION_1_3_17, releaseInputs[15]);
-        assertEquals(ReleaseInputs.VERSION_1_3_18, releaseInputs[16]);
-        assertEquals(ReleaseInputs.VERSION_1_3_19, releaseInputs[17]);
-        assertEquals(ReleaseInputs.VERSION_1_3_20, releaseInputs[18]);
+        assertEquals(20, releaseInputs.length);
+        assertEquals(ReleaseInputs.VERSION_3_2_0, releaseInputs[0]);
+        assertEquals(ReleaseInputs.VERSION_3_1_0, releaseInputs[1]);
+        assertEquals(ReleaseInputs.VERSION_3_0_0, releaseInputs[2]);
+        assertEquals(ReleaseInputs.VERSION_2_12_0, releaseInputs[3]);
+        assertEquals(ReleaseInputs.VERSION_2_13_0, releaseInputs[4]);
+        assertEquals(ReleaseInputs.VERSION_2_14_0, releaseInputs[5]);
+        assertEquals(ReleaseInputs.VERSION_2_15_0, releaseInputs[6]);
+        assertEquals(ReleaseInputs.VERSION_2_16_0, releaseInputs[7]);
+        assertEquals(ReleaseInputs.VERSION_2_17_0, releaseInputs[8]);
+        assertEquals(ReleaseInputs.VERSION_2_18_0, releaseInputs[9]);
+        assertEquals(ReleaseInputs.VERSION_2_19_0, releaseInputs[10]);
+        assertEquals(ReleaseInputs.VERSION_2_19_1, releaseInputs[11]);
+        assertEquals(ReleaseInputs.VERSION_2_19_2, releaseInputs[12]);
+        assertEquals(ReleaseInputs.VERSION_2_19_3, releaseInputs[13]);
+        assertEquals(ReleaseInputs.VERSION_1_3_15, releaseInputs[14]);
+        assertEquals(ReleaseInputs.VERSION_1_3_16, releaseInputs[15]);
+        assertEquals(ReleaseInputs.VERSION_1_3_17, releaseInputs[16]);
+        assertEquals(ReleaseInputs.VERSION_1_3_18, releaseInputs[17]);
+        assertEquals(ReleaseInputs.VERSION_1_3_19, releaseInputs[18]);
+        assertEquals(ReleaseInputs.VERSION_1_3_20, releaseInputs[19]);
     }
 
 }


### PR DESCRIPTION
### Description
Adds 3.2 version for tracking and closes 2.19.3

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/5595

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
