### PR TITLE
Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/cdk-ci-test.yml
+++ b/.github/workflows/cdk-ci-test.yml
@@ -9,13 +9,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v2.4.1
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-node@270253e841af726300e85d718a5f606959b2903c # v2.4.1
         with:
           node-version: '20.8.0'
 
       - name: Setup Java 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: 'corretto'
           java-version: '17'
@@ -28,6 +28,6 @@ jobs:
           npm test -- --coverage
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/github-merit-badger.yml
+++ b/.github/workflows/github-merit-badger.yml
@@ -11,7 +11,7 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: aws-github-ops/github-merit-badger@v0.0.98
+      - uses: aws-github-ops/github-merit-badger@949750c3f54985fad4715e77f88942be7547f1bc # v0.0.98
         id: merit-badger
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/java-ci-test.yml
+++ b/.github/workflows/java-ci-test.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
 
       - name: Setup Java 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: 'corretto'
           java-version: '17'
@@ -26,11 +26,11 @@ jobs:
           ./gradlew clean build
 
       - name: Upload Coverage Report
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: always()
         with:
           name: opensearch-metrics-coverage-reports

--- a/.github/workflows/license-checker.yml
+++ b/.github/workflows/license-checker.yml
@@ -7,6 +7,6 @@
       license-header-checker:
         runs-on: ubuntu-latest
         steps:
-          - uses: actions/checkout@v3
+          - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
           - name: Check License Header
             run: npx @kt3k/license-checker


### PR DESCRIPTION
### Description

Pin all GitHub Action tag references to their corresponding commit SHAs.

Tags are mutable references that can be force-pushed to point to different commits, making them vulnerable to supply chain attacks. Commit SHAs are immutable and guarantee that the exact reviewed code is executed in CI workflows. This change pins all third-party actions to their current commit SHAs to prevent potential tampering.